### PR TITLE
Add Prisma models and trigram patient search indexes

### DIFF
--- a/prisma/migrations/20240413000001_init_schema/migration.sql
+++ b/prisma/migrations/20240413000001_init_schema/migration.sql
@@ -1,0 +1,130 @@
+-- CreateEnum
+CREATE TYPE "Gender" AS ENUM ('M', 'F');
+CREATE TYPE "Role" AS ENUM ('Doctor', 'Admin', 'Auditor');
+
+-- CreateTable
+CREATE TABLE "Patient" (
+    "patientId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" TEXT NOT NULL,
+    "dob" DATE NOT NULL,
+    "gender" "Gender" NOT NULL,
+    "contact" TEXT,
+    "insurance" TEXT,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Patient_pkey" PRIMARY KEY ("patientId")
+);
+
+CREATE TABLE "Doctor" (
+    "doctorId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" TEXT NOT NULL,
+    "department" TEXT NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Doctor_pkey" PRIMARY KEY ("doctorId")
+);
+
+CREATE TABLE "Visit" (
+    "visitId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "patientId" UUID NOT NULL,
+    "visitDate" DATE NOT NULL,
+    "doctorId" UUID NOT NULL,
+    "department" TEXT NOT NULL,
+    "reason" TEXT,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Visit_pkey" PRIMARY KEY ("visitId"),
+    CONSTRAINT "Visit_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("patientId") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Visit_doctorId_fkey" FOREIGN KEY ("doctorId") REFERENCES "Doctor"("doctorId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "Diagnosis" (
+    "diagId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "visitId" UUID NOT NULL,
+    "diagnosis" TEXT NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Diagnosis_pkey" PRIMARY KEY ("diagId"),
+    CONSTRAINT "Diagnosis_visitId_fkey" FOREIGN KEY ("visitId") REFERENCES "Visit"("visitId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "Medication" (
+    "medId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "visitId" UUID NOT NULL,
+    "drugName" TEXT NOT NULL,
+    "dosage" TEXT,
+    "instructions" TEXT,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Medication_pkey" PRIMARY KEY ("medId"),
+    CONSTRAINT "Medication_visitId_fkey" FOREIGN KEY ("visitId") REFERENCES "Visit"("visitId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "LabResult" (
+    "labId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "visitId" UUID NOT NULL,
+    "testName" TEXT NOT NULL,
+    "resultValue" DOUBLE PRECISION,
+    "unit" TEXT,
+    "referenceRange" TEXT,
+    "testDate" DATE,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "LabResult_pkey" PRIMARY KEY ("labId"),
+    CONSTRAINT "LabResult_visitId_fkey" FOREIGN KEY ("visitId") REFERENCES "Visit"("visitId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "Observation" (
+    "obsId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "visitId" UUID NOT NULL,
+    "patientId" UUID NOT NULL,
+    "doctorId" UUID NOT NULL,
+    "noteText" TEXT NOT NULL,
+    "bpSystolic" INTEGER,
+    "bpDiastolic" INTEGER,
+    "heartRate" INTEGER,
+    "temperatureC" DOUBLE PRECISION,
+    "spo2" INTEGER,
+    "bmi" DOUBLE PRECISION,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Observation_pkey" PRIMARY KEY ("obsId"),
+    CONSTRAINT "Observation_visitId_fkey" FOREIGN KEY ("visitId") REFERENCES "Visit"("visitId") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Observation_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("patientId") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Observation_doctorId_fkey" FOREIGN KEY ("doctorId") REFERENCES "Doctor"("doctorId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "User" (
+    "userId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "role" "Role" NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "User_pkey" PRIMARY KEY ("userId")
+);
+
+CREATE TABLE "Session" (
+    "sessionId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "userId" UUID NOT NULL,
+    "refreshTokenHash" TEXT NOT NULL,
+    "issuedAt" TIMESTAMPTZ(3) NOT NULL,
+    "expiresAt" TIMESTAMPTZ(3) NOT NULL,
+    "revokedAt" TIMESTAMPTZ(3),
+    "ip" TEXT,
+    "ua" TEXT,
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("sessionId"),
+    CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("userId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "AuthAudit" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "userId" UUID,
+    "event" TEXT NOT NULL,
+    "outcome" TEXT NOT NULL,
+    "meta" JSONB,
+    "ts" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AuthAudit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+CREATE INDEX "Visit_patientId_visitDate_idx" ON "Visit"("patientId", "visitDate" DESC);
+CREATE INDEX "Visit_doctorId_visitDate_idx" ON "Visit"("doctorId", "visitDate" DESC);
+CREATE INDEX "Observation_patientId_doctorId_createdAt_idx" ON "Observation"("patientId", "doctorId", "createdAt" DESC);

--- a/prisma/migrations/20240413000002_add_patient_trgm/migration.sql
+++ b/prisma/migrations/20240413000002_add_patient_trgm/migration.sql
@@ -1,0 +1,3 @@
+-- Create trigram indexes for patient search
+CREATE INDEX IF NOT EXISTS "Patient_name_trgm_idx" ON "Patient" USING GIN ("name" gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS "Patient_contact_trgm_idx" ON "Patient" USING GIN ("contact" gin_trgm_ops);

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,3 +10,147 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Gender {
+  M
+  F
+}
+
+enum Role {
+  Doctor
+  Admin
+  Auditor
+}
+
+model Patient {
+  patientId  String   @id @default(uuid()) @db.Uuid
+  name       String
+  dob        DateTime @db.Date
+  gender     Gender
+  contact    String?
+  insurance  String?
+  createdAt  DateTime @default(now()) @db.Timestamptz(6)
+  updatedAt  DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+
+  visits      Visit[]
+  observations Observation[]
+}
+
+model Doctor {
+  doctorId  String   @id @default(uuid()) @db.Uuid
+  name      String
+  department String
+  createdAt DateTime @default(now())
+
+  visits      Visit[]
+  observations Observation[]
+}
+
+model Visit {
+  visitId   String   @id @default(uuid()) @db.Uuid
+  patientId String
+  visitDate DateTime @db.Date
+  doctorId  String
+  department String
+  reason     String?
+  createdAt  DateTime @default(now())
+
+  patient Patient @relation(fields: [patientId], references: [patientId])
+  doctor  Doctor  @relation(fields: [doctorId], references: [doctorId])
+  diagnoses   Diagnosis[]
+  medications Medication[]
+  labResults  LabResult[]
+  observations Observation[]
+
+  @@index([patientId, visitDate(sort: Desc)])
+  @@index([doctorId, visitDate(sort: Desc)])
+}
+
+model Diagnosis {
+  diagId   String   @id @default(uuid()) @db.Uuid
+  visitId  String
+  diagnosis String
+  createdAt DateTime @default(now())
+
+  visit Visit @relation(fields: [visitId], references: [visitId])
+}
+
+model Medication {
+  medId       String   @id @default(uuid()) @db.Uuid
+  visitId     String
+  drugName    String
+  dosage      String?
+  instructions String?
+  createdAt   DateTime @default(now())
+
+  visit Visit @relation(fields: [visitId], references: [visitId])
+}
+
+model LabResult {
+  labId          String   @id @default(uuid()) @db.Uuid
+  visitId        String
+  testName       String
+  resultValue    Float?
+  unit           String?
+  referenceRange String?
+  testDate       DateTime? @db.Date
+  createdAt      DateTime @default(now())
+
+  visit Visit @relation(fields: [visitId], references: [visitId])
+}
+
+model Observation {
+  obsId       String   @id @default(uuid()) @db.Uuid
+  visitId     String
+  patientId   String
+  doctorId    String
+  noteText    String
+  bpSystolic  Int?
+  bpDiastolic Int?
+  heartRate   Int?
+  temperatureC Float?
+  spo2        Int?
+  bmi         Float?
+  createdAt   DateTime @default(now())
+
+  visit   Visit  @relation(fields: [visitId], references: [visitId])
+  patient Patient @relation(fields: [patientId], references: [patientId])
+  doctor  Doctor  @relation(fields: [doctorId], references: [doctorId])
+
+  @@index([patientId, doctorId, createdAt(sort: Desc)])
+}
+
+model User {
+  userId       String   @id @default(uuid()) @db.Uuid
+  email        String   @unique
+  passwordHash String
+  role         Role
+  status       String   @default("active")
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @default(now()) @updatedAt
+
+  sessions Session[]
+}
+
+model Session {
+  sessionId        String   @id @default(uuid()) @db.Uuid
+  userId           String
+  refreshTokenHash String
+  issuedAt         DateTime
+  expiresAt        DateTime
+  revokedAt        DateTime?
+  ip               String?
+  ua               String?
+
+  user User @relation(fields: [userId], references: [userId])
+}
+
+model AuthAudit {
+  id      String   @id @default(uuid()) @db.Uuid
+  userId  String?  @db.Uuid
+  event   String
+  outcome String
+  meta    Json?
+  ts      DateTime @default(now())
+}
+
+


### PR DESCRIPTION
## Summary
- define Gender and Role enums
- add Patient, Visit, Observation and related models with indexes
- add raw migration for trigram GIN indexes on patient name/contact

## Testing
- `npx prisma migrate dev` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npx prisma generate` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*

------
https://chatgpt.com/codex/tasks/task_e_68be70f7f734832ebdaad0131c636838