### PR TITLE
scaffold api module routers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import morgan from 'morgan';
+import { apiRouter } from './server';
 import { errorHandler } from './middleware/errorHandler';
 
 export const app = express();
@@ -19,8 +20,10 @@ app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
-// Error handler should be last
-app.use(errorHandler);
+app.use('/api', apiRouter);
+
+// Error handler should be last and only apply to /api routes
+app.use('/api', errorHandler);
 
 if (process.env.NODE_ENV !== 'test') {
   const port = process.env.PORT || 8080;

--- a/src/modules/audit/index.ts
+++ b/src/modules/audit/index.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/modules/diagnoses/index.ts
+++ b/src/modules/diagnoses/index.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/modules/doctors/index.ts
+++ b/src/modules/doctors/index.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/modules/insights/index.ts
+++ b/src/modules/insights/index.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/modules/labs/index.ts
+++ b/src/modules/labs/index.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/modules/medications/index.ts
+++ b/src/modules/medications/index.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/modules/observations/index.ts
+++ b/src/modules/observations/index.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/modules/patients/index.ts
+++ b/src/modules/patients/index.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/modules/visits/index.ts
+++ b/src/modules/visits/index.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+
+import authRouter from './modules/auth';
+import patientsRouter from './modules/patients';
+import doctorsRouter from './modules/doctors';
+import visitsRouter from './modules/visits';
+import diagnosesRouter from './modules/diagnoses';
+import medicationsRouter from './modules/medications';
+import labsRouter from './modules/labs';
+import observationsRouter from './modules/observations';
+import insightsRouter from './modules/insights';
+import auditRouter from './modules/audit';
+
+export const apiRouter = Router();
+
+apiRouter.use('/auth', authRouter);
+apiRouter.use('/patients', patientsRouter);
+apiRouter.use('/doctors', doctorsRouter);
+apiRouter.use('/visits', visitsRouter);
+apiRouter.use('/diagnoses', diagnosesRouter);
+apiRouter.use('/medications', medicationsRouter);
+apiRouter.use('/labs', labsRouter);
+apiRouter.use('/observations', observationsRouter);
+apiRouter.use('/insights', insightsRouter);
+apiRouter.use('/audit', auditRouter);
+
+export default apiRouter;

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import { app } from '../src/index';
+
+describe('Health endpoint', () => {
+  it('responds with status ok', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary
- scaffold router placeholders for auth, patients, doctors, visits, diagnoses, medications, labs, observations, insights, and audit
- combine module routers in new api router and mount on /api
- apply error handler only to /api routes and add basic health endpoint test

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68be74368c20832e9047b31e4ef3b92e