### PR TITLE
feat: implement patient search and summary endpoints

### DIFF
--- a/src/modules/patients/index.ts
+++ b/src/modules/patients/index.ts
@@ -1,5 +1,84 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { requireAuth } from '../auth';
 
+const prisma = new PrismaClient();
 const router = Router();
+
+function maskContact(contact?: string | null) {
+  if (!contact) return contact;
+  return contact.replace(/.(?=.{2})/g, '*');
+}
+
+router.get('/', requireAuth, async (req: Request, res: Response) => {
+  const q = (req.query.query as string) || '';
+  if (!q.trim()) {
+    return res.status(400).json({ error: 'query required' });
+  }
+  const limit = Math.min(parseInt(req.query.limit as string) || 20, 50);
+  const offset = parseInt(req.query.offset as string) || 0;
+  const lowerQ = q.toLowerCase();
+  const patients = await prisma.$queryRaw<Array<{ patientId: string; name: string; dob: Date; insurance: string | null }>>(
+    Prisma.sql`
+      SELECT "patientId", name, dob, insurance
+      FROM "Patient"
+      WHERE lower(name) % ${lowerQ}
+      ORDER BY similarity(lower(name), ${lowerQ}) DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `
+  );
+  console.log('patient search', { q, count: patients.length });
+  res.json(patients);
+});
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const include = req.query.include === 'summary';
+  const select: any = {
+    patientId: true,
+    name: true,
+    dob: true,
+    gender: true,
+    contact: true,
+    insurance: true,
+  };
+  if (include) {
+    select.visits = {
+      orderBy: { visitDate: 'desc' },
+      take: 3,
+      select: {
+        visitId: true,
+        visitDate: true,
+        diagnoses: { select: { diagnosis: true } },
+        medications: { select: { drugName: true, dosage: true, instructions: true } },
+        labResults: {
+          where: { testName: { in: ['HbA1c', 'LDL'] } },
+          select: { testName: true, resultValue: true, unit: true, testDate: true },
+        },
+        observations: {
+          orderBy: { createdAt: 'desc' },
+          take: 2,
+          select: {
+            obsId: true,
+            noteText: true,
+            bpSystolic: true,
+            bpDiastolic: true,
+            heartRate: true,
+            temperatureC: true,
+            spo2: true,
+            bmi: true,
+            createdAt: true,
+          },
+        },
+      },
+    };
+  }
+  const patient = await prisma.patient.findUnique({ where: { patientId: id }, select });
+  if (!patient) {
+    return res.sendStatus(404);
+  }
+  console.log('patient detail', { patientId: id, contact: maskContact(patient.contact) });
+  res.json(patient);
+});
 
 export default router;

--- a/tests/patients.test.ts
+++ b/tests/patients.test.ts
@@ -1,0 +1,73 @@
+import request from 'supertest';
+import { app } from '../src/index';
+import { PrismaClient } from '@prisma/client';
+import jwt from 'jsonwebtoken';
+
+const prisma = new PrismaClient();
+let token: string;
+let patientId: string;
+
+beforeAll(async () => {
+  await prisma.$executeRaw`CREATE EXTENSION IF NOT EXISTS "pg_trgm"`;
+  const user = await prisma.user.create({ data: { email: 'doc@example.com', passwordHash: 'x', role: 'Doctor' } });
+  token = jwt.sign({ role: 'Doctor' }, 'changeme', { subject: user.userId });
+  const doctor = await prisma.doctor.create({ data: { name: 'Dr. Who', department: 'General' } });
+  const patient = await prisma.patient.create({
+    data: { name: 'John Doe', dob: new Date('1980-01-01'), gender: 'M', contact: '5551234', insurance: 'Aetna' },
+  });
+  patientId = patient.patientId;
+  await prisma.patient.create({ data: { name: 'Jane Smith', dob: new Date('1990-01-01'), gender: 'F', contact: '5555678', insurance: 'Aetna' } });
+  const visit1 = await prisma.visit.create({ data: { patientId: patient.patientId, doctorId: doctor.doctorId, visitDate: new Date('2023-01-01'), department: 'Cardiology', reason: 'checkup' } });
+  const visit2 = await prisma.visit.create({ data: { patientId: patient.patientId, doctorId: doctor.doctorId, visitDate: new Date('2023-02-01'), department: 'Endocrinology', reason: 'follow-up' } });
+  await prisma.diagnosis.create({ data: { visitId: visit2.visitId, diagnosis: 'Diabetes' } });
+  await prisma.medication.create({ data: { visitId: visit2.visitId, drugName: 'Metformin', dosage: '500mg' } });
+  await prisma.labResult.create({ data: { visitId: visit2.visitId, testName: 'HbA1c', resultValue: 7.2, unit: '%', testDate: new Date('2023-02-01') } });
+  await prisma.observation.create({ data: { visitId: visit2.visitId, patientId: patient.patientId, doctorId: doctor.doctorId, noteText: 'note1' } });
+  await prisma.observation.create({ data: { visitId: visit2.visitId, patientId: patient.patientId, doctorId: doctor.doctorId, noteText: 'note2' } });
+  await prisma.diagnosis.create({ data: { visitId: visit1.visitId, diagnosis: 'Hypertension' } });
+  await prisma.medication.create({ data: { visitId: visit1.visitId, drugName: 'Lisinopril', dosage: '10mg' } });
+  await prisma.labResult.create({ data: { visitId: visit1.visitId, testName: 'LDL', resultValue: 100, unit: 'mg/dL', testDate: new Date('2023-01-01') } });
+  await prisma.observation.create({ data: { visitId: visit1.visitId, patientId: patient.patientId, doctorId: doctor.doctorId, noteText: 'noteA' } });
+  await prisma.observation.create({ data: { visitId: visit1.visitId, patientId: patient.patientId, doctorId: doctor.doctorId, noteText: 'noteB' } });
+});
+
+afterAll(async () => {
+  await prisma.observation.deleteMany({});
+  await prisma.labResult.deleteMany({});
+  await prisma.medication.deleteMany({});
+  await prisma.diagnosis.deleteMany({});
+  await prisma.visit.deleteMany({});
+  await prisma.patient.deleteMany({});
+  await prisma.doctor.deleteMany({});
+  await prisma.user.deleteMany({});
+  await prisma.$disconnect();
+});
+
+describe('GET /api/patients search', () => {
+  it('finds patient by fuzzy name', async () => {
+    const res = await request(app)
+      .get('/api/patients')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ query: 'Jon Doe' });
+    expect(res.status).toBe(200);
+    const names = res.body.map((p: any) => p.name);
+    expect(names).toContain('John Doe');
+  });
+});
+
+describe('GET /api/patients/:id summary', () => {
+  it('returns patient summary with visits', async () => {
+    const res = await request(app)
+      .get(`/api/patients/${patientId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .query({ include: 'summary' });
+    expect(res.status).toBe(200);
+    expect(res.body.patientId).toBe(patientId);
+    expect(res.body.visits.length).toBeGreaterThan(0);
+    const visit = res.body.visits[0];
+    expect(visit.diagnoses.length).toBeGreaterThan(0);
+    expect(visit.medications.length).toBeGreaterThan(0);
+    expect(visit.labResults.length).toBeGreaterThan(0);
+    expect(visit.observations.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add patient search with trigram similarity and pagination
- return patient details with optional visit summary data
- cover new endpoints with tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68be784a9d98832ebe7195489ca2499b