### PR TITLE
feat: add doctor search and visit lifecycle endpoints

### DIFF
--- a/src/modules/doctors/index.ts
+++ b/src/modules/doctors/index.ts
@@ -1,5 +1,34 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+import { requireAuth } from '../auth';
 
+const prisma = new PrismaClient();
 const router = Router();
+
+const querySchema = z.object({
+  department: z.string().optional(),
+  q: z.string().optional(),
+});
+
+router.get('/', requireAuth, async (req: Request, res: Response) => {
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid query' });
+  }
+  const { department, q } = parsed.data;
+  if (!department && !q) {
+    return res.status(400).json({ error: 'department or q required' });
+  }
+  const where: any = {};
+  if (department) {
+    where.department = { contains: department, mode: 'insensitive' };
+  }
+  if (q) {
+    where.name = { contains: q, mode: 'insensitive' };
+  }
+  const doctors = await prisma.doctor.findMany({ where, orderBy: { name: 'asc' } });
+  res.json(doctors);
+});
 
 export default router;

--- a/src/modules/visits/index.ts
+++ b/src/modules/visits/index.ts
@@ -1,5 +1,61 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+import { requireAuth, requireRole } from '../auth';
+import type { AuthRequest } from '../auth/middleware';
 
+const prisma = new PrismaClient();
 const router = Router();
+
+const visitSchema = z.object({
+  patientId: z.string().uuid(),
+  visitDate: z.coerce.date(),
+  doctorId: z.string().uuid(),
+  department: z.string(),
+  reason: z.string().optional(),
+});
+
+router.post('/visits', requireAuth, requireRole('Doctor', 'Admin'), async (req: AuthRequest, res: Response) => {
+  const parsed = visitSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const visit = await prisma.visit.create({ data: parsed.data });
+  res.status(201).json(visit);
+});
+
+router.get('/patients/:id/visits', requireAuth, async (req: Request, res: Response) => {
+  const id = req.params.id;
+  try {
+    z.string().uuid().parse(id);
+  } catch {
+    return res.status(400).json({ error: 'invalid id' });
+  }
+  const visits = await prisma.visit.findMany({
+    where: { patientId: id },
+    orderBy: { visitDate: 'desc' },
+  });
+  res.json(visits);
+});
+
+router.get('/visits/:id', requireAuth, async (req: Request, res: Response) => {
+  const id = req.params.id;
+  try {
+    z.string().uuid().parse(id);
+  } catch {
+    return res.status(400).json({ error: 'invalid id' });
+  }
+  const visit = await prisma.visit.findUnique({
+    where: { visitId: id },
+    include: {
+      diagnoses: { orderBy: { createdAt: 'desc' } },
+      medications: { orderBy: { createdAt: 'desc' } },
+      labResults: { orderBy: { createdAt: 'desc' } },
+      observations: { orderBy: { createdAt: 'desc' } },
+    },
+  });
+  if (!visit) return res.sendStatus(404);
+  res.json(visit);
+});
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express';
 
 import authRouter from './modules/auth';
+import visitsRouter from './modules/visits';
 import patientsRouter from './modules/patients';
 import doctorsRouter from './modules/doctors';
-import visitsRouter from './modules/visits';
 import diagnosesRouter from './modules/diagnoses';
 import medicationsRouter from './modules/medications';
 import labsRouter from './modules/labs';
@@ -14,9 +14,9 @@ import auditRouter from './modules/audit';
 export const apiRouter = Router();
 
 apiRouter.use('/auth', authRouter);
+apiRouter.use(visitsRouter);
 apiRouter.use('/patients', patientsRouter);
 apiRouter.use('/doctors', doctorsRouter);
-apiRouter.use('/visits', visitsRouter);
 apiRouter.use('/diagnoses', diagnosesRouter);
 apiRouter.use('/medications', medicationsRouter);
 apiRouter.use('/labs', labsRouter);

--- a/tests/visits.test.ts
+++ b/tests/visits.test.ts
@@ -1,0 +1,71 @@
+import request from 'supertest';
+import { app } from '../src/index';
+import { PrismaClient } from '@prisma/client';
+import jwt from 'jsonwebtoken';
+
+const prisma = new PrismaClient();
+let token: string;
+let patientId: string;
+let doctorId: string;
+let visitId: string;
+
+beforeAll(async () => {
+  const user = await prisma.user.create({ data: { email: 'visitdoc@example.com', passwordHash: 'x', role: 'Doctor' } });
+  token = jwt.sign({ role: 'Doctor' }, 'changeme', { subject: user.userId });
+  const doctor = await prisma.doctor.create({ data: { name: 'Dr. House', department: 'Diagnostics' } });
+  doctorId = doctor.doctorId;
+  const patient = await prisma.patient.create({ data: { name: 'Greg Patient', dob: new Date('1985-05-05'), gender: 'M' } });
+  patientId = patient.patientId;
+  // existing older visit for ordering
+  await prisma.visit.create({ data: { patientId, doctorId, visitDate: new Date('2023-01-01'), department: 'Diagnostics', reason: 'old' } });
+});
+
+afterAll(async () => {
+  await prisma.observation.deleteMany({});
+  await prisma.labResult.deleteMany({});
+  await prisma.medication.deleteMany({});
+  await prisma.diagnosis.deleteMany({});
+  await prisma.visit.deleteMany({});
+  await prisma.patient.deleteMany({});
+  await prisma.doctor.deleteMany({});
+  await prisma.user.deleteMany({});
+  await prisma.$disconnect();
+});
+
+describe('Visit lifecycle', () => {
+  it('creates and retrieves visit details', async () => {
+    const createRes = await request(app)
+      .post('/api/visits')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        patientId,
+        visitDate: '2023-03-01',
+        doctorId,
+        department: 'Diagnostics',
+        reason: 'checkup',
+      });
+    expect(createRes.status).toBe(201);
+    visitId = createRes.body.visitId;
+
+    await prisma.diagnosis.create({ data: { visitId, diagnosis: 'Flu' } });
+    await prisma.medication.create({ data: { visitId, drugName: 'Tamiflu' } });
+    await prisma.labResult.create({ data: { visitId, testName: 'CBC', resultValue: 4.5, unit: 'x', testDate: new Date('2023-03-02') } });
+    await prisma.observation.create({ data: { visitId, patientId, doctorId, noteText: 'note1', createdAt: new Date('2023-03-02') } });
+    await prisma.observation.create({ data: { visitId, patientId, doctorId, noteText: 'note2', createdAt: new Date('2023-03-03') } });
+
+    const listRes = await request(app)
+      .get(`/api/patients/${patientId}/visits`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(listRes.status).toBe(200);
+    expect(listRes.body[0].visitId).toBe(visitId);
+
+    const detailRes = await request(app)
+      .get(`/api/visits/${visitId}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(detailRes.status).toBe(200);
+    expect(detailRes.body.diagnoses[0].diagnosis).toBe('Flu');
+    expect(detailRes.body.medications[0].drugName).toBe('Tamiflu');
+    expect(detailRes.body.labResults[0].testName).toBe('CBC');
+    expect(detailRes.body.observations[0].noteText).toBe('note2');
+  });
+});


### PR DESCRIPTION
## Summary
- implement doctor search endpoint filtered by name and department
- add visit creation, listing, and detailed retrieval with zod validation and RBAC
- cover visit lifecycle with automated test and adjust API routing

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68be9b0aa044832ea4cea16c62b9fda4