### PR TITLE
Add endpoints for diagnoses, medications, and labs

### DIFF
--- a/src/modules/diagnoses/index.ts
+++ b/src/modules/diagnoses/index.ts
@@ -1,5 +1,61 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+import { requireAuth, requireRole } from '../auth';
+import type { AuthRequest } from '../auth/middleware';
 
+const prisma = new PrismaClient();
 const router = Router();
+
+const diagnosisSchema = z.object({
+  diagnosis: z.string().min(1),
+});
+
+router.post('/visits/:id/diagnoses', requireAuth, requireRole('Doctor', 'Admin'), async (req: AuthRequest, res: Response) => {
+  const { id } = req.params;
+  try {
+    z.string().uuid().parse(id);
+  } catch {
+    return res.status(400).json({ error: 'invalid id' });
+  }
+  const parsed = diagnosisSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const diag = await prisma.diagnosis.create({ data: { visitId: id, diagnosis: parsed.data.diagnosis } });
+  res.status(201).json(diag);
+});
+
+router.get('/', requireAuth, requireRole('Doctor', 'Admin'), async (req: Request, res: Response) => {
+  const querySchema = z.object({
+    q: z.string().optional(),
+    from: z.coerce.date().optional(),
+    to: z.coerce.date().optional(),
+    limit: z.coerce.number().int().positive().max(50).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+  });
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const { q, from, to, limit = 20, offset = 0 } = parsed.data;
+  const where: any = {};
+  if (q) {
+    where.diagnosis = { contains: q, mode: 'insensitive' };
+  }
+  if (from || to) {
+    where.createdAt = {
+      ...(from && { gte: from }),
+      ...(to && { lte: to }),
+    };
+  }
+  const diagnoses = await prisma.diagnosis.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+    skip: offset,
+  });
+  res.json(diagnoses);
+});
 
 export default router;

--- a/src/modules/labs/index.ts
+++ b/src/modules/labs/index.ts
@@ -1,5 +1,77 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+import { requireAuth, requireRole } from '../auth';
+import type { AuthRequest } from '../auth/middleware';
 
+const prisma = new PrismaClient();
 const router = Router();
+
+const labSchema = z.object({
+  testName: z.string().min(1),
+  resultValue: z.number().optional(),
+  unit: z.string().optional(),
+  referenceRange: z.string().optional(),
+  testDate: z.coerce.date().optional(),
+});
+
+router.post('/visits/:id/labs', requireAuth, requireRole('Doctor', 'Admin'), async (req: AuthRequest, res: Response) => {
+  const { id } = req.params;
+  try {
+    z.string().uuid().parse(id);
+  } catch {
+    return res.status(400).json({ error: 'invalid id' });
+  }
+  const parsed = labSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const lab = await prisma.labResult.create({ data: { visitId: id, ...parsed.data } });
+  res.status(201).json(lab);
+});
+
+router.get('/', requireAuth, requireRole('Doctor', 'Admin'), async (req: Request, res: Response) => {
+  const querySchema = z.object({
+    patient_id: z.string().uuid().optional(),
+    test_name: z.string().optional(),
+    min: z.coerce.number().optional(),
+    max: z.coerce.number().optional(),
+    from: z.coerce.date().optional(),
+    to: z.coerce.date().optional(),
+    limit: z.coerce.number().int().positive().max(50).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+  });
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const { patient_id, test_name, min, max, from, to, limit = 20, offset = 0 } = parsed.data;
+  const where: any = {};
+  if (patient_id) {
+    where.visit = { patientId: patient_id };
+  }
+  if (test_name) {
+    where.testName = { contains: test_name, mode: 'insensitive' };
+  }
+  if (min !== undefined || max !== undefined) {
+    where.resultValue = {
+      ...(min !== undefined && { gte: min }),
+      ...(max !== undefined && { lte: max }),
+    };
+  }
+  if (from || to) {
+    where.testDate = {
+      ...(from && { gte: from }),
+      ...(to && { lte: to }),
+    };
+  }
+  const labs = await prisma.labResult.findMany({
+    where,
+    orderBy: { testDate: 'desc' },
+    take: limit,
+    skip: offset,
+  });
+  res.json(labs);
+});
 
 export default router;

--- a/src/modules/medications/index.ts
+++ b/src/modules/medications/index.ts
@@ -1,5 +1,64 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+import { requireAuth, requireRole } from '../auth';
+import type { AuthRequest } from '../auth/middleware';
 
+const prisma = new PrismaClient();
 const router = Router();
+
+const medicationSchema = z.object({
+  drugName: z.string().min(1),
+  dosage: z.string().optional(),
+  instructions: z.string().optional(),
+});
+
+router.post('/visits/:id/medications', requireAuth, requireRole('Doctor', 'Admin'), async (req: AuthRequest, res: Response) => {
+  const { id } = req.params;
+  try {
+    z.string().uuid().parse(id);
+  } catch {
+    return res.status(400).json({ error: 'invalid id' });
+  }
+  const parsed = medicationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const med = await prisma.medication.create({ data: { visitId: id, ...parsed.data } });
+  res.status(201).json(med);
+});
+
+router.get('/', requireAuth, requireRole('Doctor', 'Admin'), async (req: Request, res: Response) => {
+  const querySchema = z.object({
+    patient_id: z.string().uuid().optional(),
+    from: z.coerce.date().optional(),
+    to: z.coerce.date().optional(),
+    limit: z.coerce.number().int().positive().max(50).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+  });
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const { patient_id, from, to, limit = 20, offset = 0 } = parsed.data;
+  const where: any = {};
+  if (patient_id || from || to) {
+    where.visit = {};
+    if (patient_id) where.visit.patientId = patient_id;
+    if (from || to) {
+      where.visit.visitDate = {
+        ...(from && { gte: from }),
+        ...(to && { lte: to }),
+      };
+    }
+  }
+  const meds = await prisma.medication.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+    skip: offset,
+  });
+  res.json(meds);
+});
 
 export default router;

--- a/tests/diagnoses.test.ts
+++ b/tests/diagnoses.test.ts
@@ -1,0 +1,54 @@
+import request from 'supertest';
+import { app } from '../src/index';
+import { PrismaClient } from '@prisma/client';
+import jwt from 'jsonwebtoken';
+
+const prisma = new PrismaClient();
+let token: string;
+let visitId: string;
+let patientId: string;
+
+beforeAll(async () => {
+  const user = await prisma.user.create({ data: { email: 'diagdoc@example.com', passwordHash: 'x', role: 'Doctor' } });
+  token = jwt.sign({ role: 'Doctor' }, 'changeme', { subject: user.userId });
+  const doctor = await prisma.doctor.create({ data: { name: 'Dr. D', department: 'General' } });
+  const patient = await prisma.patient.create({ data: { name: 'Diag Pat', dob: new Date('1990-01-01'), gender: 'F' } });
+  patientId = patient.patientId;
+  const visit = await prisma.visit.create({ data: { patientId, doctorId: doctor.doctorId, visitDate: new Date('2023-01-01'), department: 'General' } });
+  visitId = visit.visitId;
+});
+
+afterAll(async () => {
+  await prisma.diagnosis.deleteMany({});
+  await prisma.visit.deleteMany({});
+  await prisma.patient.deleteMany({});
+  await prisma.doctor.deleteMany({});
+  await prisma.user.deleteMany({});
+  await prisma.$disconnect();
+});
+
+describe('Diagnoses', () => {
+  it('creates diagnosis and lists', async () => {
+    const createRes = await request(app)
+      .post(`/api/visits/${visitId}/diagnoses`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ diagnosis: 'Flu' });
+    expect(createRes.status).toBe(201);
+
+    const listRes = await request(app)
+      .get('/api/diagnoses?q=Flu&from=2022-01-01&to=2024-01-01')
+      .set('Authorization', `Bearer ${token}`);
+    expect(listRes.status).toBe(200);
+    expect(listRes.body[0].diagnosis).toBe('Flu');
+  });
+
+  it('forbids non doctor/admin', async () => {
+    const user = await prisma.user.create({ data: { email: 'auditorDiag@example.com', passwordHash: 'x', role: 'Auditor' } });
+    const auditorToken = jwt.sign({ role: 'Auditor' }, 'changeme', { subject: user.userId });
+    const res = await request(app)
+      .post(`/api/visits/${visitId}/diagnoses`)
+      .set('Authorization', `Bearer ${auditorToken}`)
+      .send({ diagnosis: 'Cold' });
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/labs.test.ts
+++ b/tests/labs.test.ts
@@ -1,0 +1,54 @@
+import request from 'supertest';
+import { app } from '../src/index';
+import { PrismaClient } from '@prisma/client';
+import jwt from 'jsonwebtoken';
+
+const prisma = new PrismaClient();
+let token: string;
+let visitId: string;
+let patientId: string;
+
+beforeAll(async () => {
+  const user = await prisma.user.create({ data: { email: 'labdoc@example.com', passwordHash: 'x', role: 'Doctor' } });
+  token = jwt.sign({ role: 'Doctor' }, 'changeme', { subject: user.userId });
+  const doctor = await prisma.doctor.create({ data: { name: 'Dr. L', department: 'Lab' } });
+  const patient = await prisma.patient.create({ data: { name: 'Lab Pat', dob: new Date('1990-01-01'), gender: 'F' } });
+  patientId = patient.patientId;
+  const visit = await prisma.visit.create({ data: { patientId, doctorId: doctor.doctorId, visitDate: new Date('2023-03-01'), department: 'Lab' } });
+  visitId = visit.visitId;
+});
+
+afterAll(async () => {
+  await prisma.labResult.deleteMany({});
+  await prisma.visit.deleteMany({});
+  await prisma.patient.deleteMany({});
+  await prisma.doctor.deleteMany({});
+  await prisma.user.deleteMany({});
+  await prisma.$disconnect();
+});
+
+describe('Lab results', () => {
+  it('creates lab and lists with filters', async () => {
+    const createRes = await request(app)
+      .post(`/api/visits/${visitId}/labs`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ testName: 'CBC', resultValue: 4.5, unit: 'x', testDate: '2023-03-02' });
+    expect(createRes.status).toBe(201);
+
+    const listRes = await request(app)
+      .get(`/api/labs?patient_id=${patientId}&test_name=CBC&min=4&max=5&from=2023-03-01&to=2023-03-10`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(listRes.status).toBe(200);
+    expect(listRes.body[0].testName).toBe('CBC');
+  });
+
+  it('enforces role', async () => {
+    const user = await prisma.user.create({ data: { email: 'audlab@example.com', passwordHash: 'x', role: 'Auditor' } });
+    const auditorToken = jwt.sign({ role: 'Auditor' }, 'changeme', { subject: user.userId });
+    const res = await request(app)
+      .post(`/api/visits/${visitId}/labs`)
+      .set('Authorization', `Bearer ${auditorToken}`)
+      .send({ testName: 'BMP' });
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/medications.test.ts
+++ b/tests/medications.test.ts
@@ -1,0 +1,54 @@
+import request from 'supertest';
+import { app } from '../src/index';
+import { PrismaClient } from '@prisma/client';
+import jwt from 'jsonwebtoken';
+
+const prisma = new PrismaClient();
+let token: string;
+let visitId: string;
+let patientId: string;
+
+beforeAll(async () => {
+  const user = await prisma.user.create({ data: { email: 'meddoc@example.com', passwordHash: 'x', role: 'Doctor' } });
+  token = jwt.sign({ role: 'Doctor' }, 'changeme', { subject: user.userId });
+  const doctor = await prisma.doctor.create({ data: { name: 'Dr. M', department: 'Pharma' } });
+  const patient = await prisma.patient.create({ data: { name: 'Med Pat', dob: new Date('1990-01-01'), gender: 'M' } });
+  patientId = patient.patientId;
+  const visit = await prisma.visit.create({ data: { patientId, doctorId: doctor.doctorId, visitDate: new Date('2023-02-01'), department: 'Pharma' } });
+  visitId = visit.visitId;
+});
+
+afterAll(async () => {
+  await prisma.medication.deleteMany({});
+  await prisma.visit.deleteMany({});
+  await prisma.patient.deleteMany({});
+  await prisma.doctor.deleteMany({});
+  await prisma.user.deleteMany({});
+  await prisma.$disconnect();
+});
+
+describe('Medications', () => {
+  it('creates medication and lists', async () => {
+    const createRes = await request(app)
+      .post(`/api/visits/${visitId}/medications`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ drugName: 'Aspirin', dosage: '100mg' });
+    expect(createRes.status).toBe(201);
+
+    const listRes = await request(app)
+      .get(`/api/medications?patient_id=${patientId}&from=2022-01-01&to=2024-01-01`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(listRes.status).toBe(200);
+    expect(listRes.body[0].drugName).toBe('Aspirin');
+  });
+
+  it('enforces role', async () => {
+    const user = await prisma.user.create({ data: { email: 'audmed@example.com', passwordHash: 'x', role: 'Auditor' } });
+    const auditorToken = jwt.sign({ role: 'Auditor' }, 'changeme', { subject: user.userId });
+    const res = await request(app)
+      .post(`/api/visits/${visitId}/medications`)
+      .set('Authorization', `Bearer ${auditorToken}`)
+      .send({ drugName: 'Ibuprofen' });
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add diagnosis endpoints with validation, pagination, and RBAC
- add medication endpoints and listing with query filters and role checks
- support lab result creation and search with filters and access control

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden retrieving @prisma/client)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68be9e3f617c832e9a5b62cba3996518