### PR TITLE
Add insights endpoints and cohort queries

### DIFF
--- a/src/modules/insights/index.ts
+++ b/src/modules/insights/index.ts
@@ -1,5 +1,118 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { z } from 'zod';
+import { requireAuth } from '../auth';
 
+const prisma = new PrismaClient();
 const router = Router();
+
+const summarySchema = z.object({
+  patient_id: z.string().uuid(),
+  last_n: z.coerce.number().int().positive().max(20).optional(),
+});
+
+router.get('/patient-summary', requireAuth, async (req: Request, res: Response) => {
+  const parsed = summarySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const { patient_id, last_n = 3 } = parsed.data;
+  const visits = await prisma.visit.findMany({
+    where: { patientId: patient_id },
+    orderBy: { visitDate: 'desc' },
+    take: last_n,
+    select: {
+      visitId: true,
+      visitDate: true,
+      diagnoses: { select: { diagnosis: true } },
+      medications: { select: { drugName: true, dosage: true, instructions: true } },
+      labResults: {
+        where: { testName: { in: ['HbA1c', 'LDL'] } },
+        select: { testName: true, resultValue: true, unit: true, testDate: true },
+      },
+      observations: {
+        orderBy: { createdAt: 'desc' },
+        take: 2,
+        select: {
+          obsId: true,
+          noteText: true,
+          bpSystolic: true,
+          bpDiastolic: true,
+          heartRate: true,
+          temperatureC: true,
+          spo2: true,
+          bmi: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+  res.json({ patientId: patient_id, visits });
+});
+
+const latestSchema = z.object({ patient_id: z.string().uuid() });
+
+router.get('/latest-visit', requireAuth, async (req: Request, res: Response) => {
+  const parsed = latestSchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const { patient_id } = parsed.data;
+  const visit = await prisma.visit.findFirst({
+    where: { patientId: patient_id },
+    orderBy: { visitDate: 'desc' },
+    include: {
+      diagnoses: { orderBy: { createdAt: 'desc' } },
+      medications: { orderBy: { createdAt: 'desc' } },
+      labResults: { orderBy: { createdAt: 'desc' } },
+      observations: { orderBy: { createdAt: 'desc' } },
+    },
+  });
+  if (!visit) return res.sendStatus(404);
+  res.json(visit);
+});
+
+const cohortSchema = z.object({
+  test_name: z.string().min(1),
+  op: z.enum(['gt', 'gte', 'lt', 'lte', 'eq']).default('gt'),
+  value: z.coerce.number(),
+  months: z.coerce.number().int().positive().max(120),
+});
+
+router.get('/cohort', requireAuth, async (req: Request, res: Response) => {
+  const parsed = cohortSchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const { test_name, op, value, months } = parsed.data;
+  const opMap: Record<string, string> = {
+    gt: '>',
+    gte: '>=',
+    lt: '<',
+    lte: '<=',
+    eq: '=',
+  };
+  const from = new Date();
+  from.setMonth(from.getMonth() - months);
+  const results = await prisma.$queryRaw<Array<{ patientId: string; name: string; value: number; date: Date; visitId: string }>>(
+    Prisma.sql`SELECT DISTINCT ON (p."patientId")
+        p."patientId", p.name, l."resultValue" AS value, l."testDate" AS date, l."visitId"
+      FROM "LabResult" l
+      JOIN "Visit" v ON l."visitId" = v."visitId"
+      JOIN "Patient" p ON v."patientId" = p."patientId"
+      WHERE l."testName" = ${test_name}
+        AND l."testDate" >= ${from}
+        AND l."resultValue" ${Prisma.raw(opMap[op])} ${value}
+        AND l."resultValue" IS NOT NULL
+        AND l."testDate" IS NOT NULL
+      ORDER BY p."patientId", l."testDate" DESC`
+  );
+  const cohort = results.map((r) => ({
+    patientId: r.patientId,
+    name: r.name,
+    lastMatchingLab: { value: r.value, date: r.date, visitId: r.visitId },
+  }));
+  res.json(cohort);
+});
 
 export default router;

--- a/tests/insights.test.ts
+++ b/tests/insights.test.ts
@@ -1,0 +1,77 @@
+import request from 'supertest';
+import { app } from '../src/index';
+import { PrismaClient } from '@prisma/client';
+import jwt from 'jsonwebtoken';
+
+const prisma = new PrismaClient();
+let token: string;
+let patient1Id: string;
+let patient2Id: string;
+let latestVisitId: string;
+
+beforeAll(async () => {
+  const user = await prisma.user.create({ data: { email: 'insights@example.com', passwordHash: 'x', role: 'Doctor' } });
+  token = jwt.sign({ role: 'Doctor' }, 'changeme', { subject: user.userId });
+  const doctor = await prisma.doctor.create({ data: { name: 'Dr. I', department: 'Insights' } });
+  const patient1 = await prisma.patient.create({ data: { name: 'Alice', dob: new Date('1980-01-01'), gender: 'F' } });
+  const patient2 = await prisma.patient.create({ data: { name: 'Bob', dob: new Date('1975-01-01'), gender: 'M' } });
+  patient1Id = patient1.patientId;
+  patient2Id = patient2.patientId;
+  const now = new Date();
+  const older = new Date(now.getFullYear(), now.getMonth() - 4, now.getDate());
+  const recent = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
+  const visitA = await prisma.visit.create({ data: { patientId: patient1Id, doctorId: doctor.doctorId, visitDate: older, department: 'Gen' } });
+  const visitB = await prisma.visit.create({ data: { patientId: patient1Id, doctorId: doctor.doctorId, visitDate: recent, department: 'Gen' } });
+  latestVisitId = visitB.visitId;
+  const visitC = await prisma.visit.create({ data: { patientId: patient2Id, doctorId: doctor.doctorId, visitDate: recent, department: 'Gen' } });
+  await prisma.diagnosis.create({ data: { visitId: visitB.visitId, diagnosis: 'Condition' } });
+  await prisma.medication.create({ data: { visitId: visitB.visitId, drugName: 'Drug', dosage: '10mg' } });
+  await prisma.labResult.create({ data: { visitId: visitA.visitId, testName: 'HbA1c', resultValue: 8.5, unit: '%', testDate: older } });
+  await prisma.labResult.create({ data: { visitId: visitB.visitId, testName: 'HbA1c', resultValue: 9.2, unit: '%', testDate: recent } });
+  await prisma.labResult.create({ data: { visitId: visitC.visitId, testName: 'HbA1c', resultValue: 7.0, unit: '%', testDate: recent } });
+});
+
+afterAll(async () => {
+  await prisma.labResult.deleteMany({});
+  await prisma.medication.deleteMany({});
+  await prisma.diagnosis.deleteMany({});
+  await prisma.visit.deleteMany({});
+  await prisma.patient.deleteMany({});
+  await prisma.doctor.deleteMany({});
+  await prisma.user.deleteMany({});
+  await prisma.$disconnect();
+});
+
+describe('Insights cohort', () => {
+  it('finds patients with high HbA1c', async () => {
+    const res = await request(app)
+      .get('/api/insights/cohort')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ test_name: 'HbA1c', op: 'gt', value: 8, months: 6 });
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].patientId).toBe(patient1Id);
+    expect(res.body[0].lastMatchingLab.value).toBeCloseTo(9.2);
+  });
+});
+
+describe('Insights summary and latest visit', () => {
+  it('returns patient summary', async () => {
+    const res = await request(app)
+      .get('/api/insights/patient-summary')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ patient_id: patient1Id, last_n: 2 });
+    expect(res.status).toBe(200);
+    expect(res.body.visits.length).toBe(2);
+  });
+
+  it('returns latest visit bundle', async () => {
+    const res = await request(app)
+      .get('/api/insights/latest-visit')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ patient_id: patient1Id });
+    expect(res.status).toBe(200);
+    expect(res.body.visitId).toBe(latestVisitId);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add patient summary, latest visit and cohort routes under insights
- enable cohort filtering on lab results using raw SQL for efficiency
- add tests for insights endpoints including HbA1c cohort check

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@prisma%2fclient)*

------
https://chatgpt.com/codex/tasks/task_e_68beae8fe9e0832e9c92ab4a1e45dda9