### PR TITLE
feat: add audit service and endpoint

### DIFF
--- a/src/modules/audit/index.ts
+++ b/src/modules/audit/index.ts
@@ -1,5 +1,42 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+import { requireAuth, requireRole } from '../auth';
+import type { AuthRequest } from '../auth/middleware';
 
+const prisma = new PrismaClient();
 const router = Router();
 
+router.get('/', requireAuth, requireRole('Admin', 'Auditor'), async (req: AuthRequest, res: Response) => {
+  const querySchema = z.object({
+    entity: z.string().optional(),
+    entity_id: z.string().optional(),
+    actor: z.string().optional(),
+    from: z.coerce.date().optional(),
+    to: z.coerce.date().optional(),
+    limit: z.coerce.number().int().positive().max(50).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+  });
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const { entity, entity_id, actor, from, to, limit = 20, offset = 0 } = parsed.data;
+  const and: any[] = [];
+  if (entity) and.push({ meta: { path: ['entity'], equals: entity } });
+  if (entity_id) and.push({ meta: { path: ['entityId'], equals: entity_id } });
+  if (actor) and.push({ meta: { path: ['actorUserId'], equals: actor } });
+  if (from || to) {
+    and.push({ ts: { ...(from && { gte: from }), ...(to && { lte: to }) } });
+  }
+  const audits = await prisma.authAudit.findMany({
+    where: { event: 'data_change', ...(and.length ? { AND: and } : {}) },
+    orderBy: { ts: 'desc' },
+    take: limit,
+    skip: offset,
+  });
+  res.json(audits);
+});
+
+export { logDataChange } from './service';
 export default router;

--- a/src/modules/audit/service.ts
+++ b/src/modules/audit/service.ts
@@ -1,0 +1,47 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+function maskContact(obj: any) {
+  if (!obj) return obj;
+  const copy = JSON.parse(JSON.stringify(obj));
+  if (typeof copy.contact === 'string') {
+    copy.contact = copy.contact.replace(/.(?=.{2})/g, '*');
+  }
+  return copy;
+}
+
+export async function logDataChange(
+  actorUserId: string,
+  entity: string,
+  entityId: string,
+  before?: any,
+  after?: any
+) {
+  const ts = new Date();
+  const meta: any = {
+    actorUserId,
+    entity,
+    entityId,
+    ts,
+  };
+  if (before !== undefined) {
+    meta.before = maskContact(before);
+  }
+  if (after !== undefined) {
+    meta.after = maskContact(after);
+  }
+  try {
+    await prisma.authAudit.create({
+      data: {
+        userId: actorUserId,
+        event: 'data_change',
+        outcome: 'success',
+        meta,
+        ts,
+      },
+    });
+  } catch (err) {
+    // ignore logging errors
+  }
+}

--- a/src/modules/diagnoses/index.ts
+++ b/src/modules/diagnoses/index.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
 import { requireAuth, requireRole } from '../auth';
 import type { AuthRequest } from '../auth/middleware';
+import { logDataChange } from '../audit';
 
 const prisma = new PrismaClient();
 const router = Router();
@@ -23,6 +24,7 @@ router.post('/visits/:id/diagnoses', requireAuth, requireRole('Doctor', 'Admin')
     return res.status(400).json({ error: parsed.error.flatten() });
   }
   const diag = await prisma.diagnosis.create({ data: { visitId: id, diagnosis: parsed.data.diagnosis } });
+  await logDataChange(req.user!.userId, 'diagnosis', diag.diagId, undefined, diag);
   res.status(201).json(diag);
 });
 

--- a/src/modules/labs/index.ts
+++ b/src/modules/labs/index.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
 import { requireAuth, requireRole } from '../auth';
 import type { AuthRequest } from '../auth/middleware';
+import { logDataChange } from '../audit';
 
 const prisma = new PrismaClient();
 const router = Router();
@@ -27,6 +28,7 @@ router.post('/visits/:id/labs', requireAuth, requireRole('Doctor', 'Admin'), asy
     return res.status(400).json({ error: parsed.error.flatten() });
   }
   const lab = await prisma.labResult.create({ data: { visitId: id, ...parsed.data } });
+  await logDataChange(req.user!.userId, 'lab', lab.labId, undefined, lab);
   res.status(201).json(lab);
 });
 

--- a/src/modules/medications/index.ts
+++ b/src/modules/medications/index.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
 import { requireAuth, requireRole } from '../auth';
 import type { AuthRequest } from '../auth/middleware';
+import { logDataChange } from '../audit';
 
 const prisma = new PrismaClient();
 const router = Router();
@@ -25,6 +26,7 @@ router.post('/visits/:id/medications', requireAuth, requireRole('Doctor', 'Admin
     return res.status(400).json({ error: parsed.error.flatten() });
   }
   const med = await prisma.medication.create({ data: { visitId: id, ...parsed.data } });
+  await logDataChange(req.user!.userId, 'medication', med.medId, undefined, med);
   res.status(201).json(med);
 });
 

--- a/src/modules/observations/index.ts
+++ b/src/modules/observations/index.ts
@@ -3,6 +3,7 @@ import { PrismaClient, Prisma, Observation } from '@prisma/client';
 import { z } from 'zod';
 import { requireAuth, requireRole } from '../auth';
 import type { AuthRequest } from '../auth/middleware';
+import { logDataChange } from '../audit';
 
 const prisma = new PrismaClient();
 const router = Router();
@@ -38,6 +39,7 @@ router.post('/visits/:id/observations', requireAuth, requireRole('Doctor'), asyn
       ...parsed.data,
     },
   });
+  await logDataChange(req.user!.userId, 'observation', obs.obsId, undefined, obs);
   res.status(201).json(obs);
 });
 

--- a/src/modules/visits/index.ts
+++ b/src/modules/visits/index.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
 import { requireAuth, requireRole } from '../auth';
 import type { AuthRequest } from '../auth/middleware';
+import { logDataChange } from '../audit';
 
 const prisma = new PrismaClient();
 const router = Router();
@@ -21,6 +22,7 @@ router.post('/visits', requireAuth, requireRole('Doctor', 'Admin'), async (req: 
     return res.status(400).json({ error: parsed.error.flatten() });
   }
   const visit = await prisma.visit.create({ data: parsed.data });
+  await logDataChange(req.user!.userId, 'visit', visit.visitId, undefined, visit);
   res.status(201).json(visit);
 });
 


### PR DESCRIPTION
## Summary
- log data changes for clinical entities
- expose audit log listing with filters

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beaf8b3abc832e9287091781ac19c2