### PR TITLE
feat: harden API security and validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,19 @@ import morgan from 'morgan';
 import { apiRouter } from './server';
 import { errorHandler } from './middleware/errorHandler';
 
-export const app = express();
+if (
+  process.env.DATABASE_URL &&
+  !process.env.DATABASE_URL.includes('sslmode=require')
+) {
+  throw new Error('sslmode=require must be set in DATABASE_URL');
+}
 
+export const app = express();
+app.disable('x-powered-by');
 app.use(helmet());
 
 if (process.env.NODE_ENV !== 'production') {
-  app.use(cors());
+  app.use(cors({ origin: 'http://localhost:5173', credentials: true }));
 }
 
 app.use(morgan('dev'));

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -8,7 +8,7 @@ export function errorHandler(
   _next: NextFunction
 ) {
   const status = err instanceof HttpError ? err.status : 500;
-  const message = err instanceof Error ? err.message : 'Internal Server Error';
+  const message = err instanceof HttpError ? err.message : 'Internal Server Error';
 
   res.status(status).json({ error: { message } });
 }

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -1,0 +1,25 @@
+import { AnyZodObject, ZodError } from 'zod';
+import { Request, Response, NextFunction } from 'express';
+import { HttpError } from '../utils/httpErrors';
+
+interface Schema {
+  body?: AnyZodObject;
+  query?: AnyZodObject;
+  params?: AnyZodObject;
+}
+
+export function validate(schema: Schema) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    try {
+      if (schema.body) req.body = schema.body.parse(req.body);
+      if (schema.query) req.query = schema.query.parse(req.query);
+      if (schema.params) req.params = schema.params.parse(req.params);
+      next();
+    } catch (err) {
+      if (err instanceof ZodError) {
+        return next(new HttpError(400, 'Invalid request'));
+      }
+      next(err);
+    }
+  };
+}

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,62 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+jest.mock('@prisma/client', () => {
+  const mPrisma = {
+    user: { findUnique: jest.fn().mockResolvedValue(null) },
+    session: { create: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
+    authAudit: { create: jest.fn() },
+    $queryRaw: jest.fn().mockResolvedValue([]),
+    patient: { findUnique: jest.fn() },
+  };
+  return { PrismaClient: jest.fn(() => mPrisma), Prisma: { sql: () => '' } };
+});
+
+describe('security headers and rate limits', () => {
+  let app: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'changeme';
+    process.env.RATE_LIMIT_MAX = '2';
+    process.env.RATE_LIMIT_WINDOW_MIN = '1';
+    const mod = await import('../src/index');
+    app = mod.app;
+  });
+
+  it('disables x-powered-by and sets helmet headers', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.headers['x-powered-by']).toBeUndefined();
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('rate limits auth routes', async () => {
+    await request(app).post('/api/auth/login').send({ email: 'a', password: 'b' });
+    await request(app).post('/api/auth/login').send({ email: 'a', password: 'b' });
+    const res = await request(app).post('/api/auth/login').send({ email: 'a', password: 'b' });
+    expect(res.status).toBe(429);
+  });
+
+  it('rate limits patient search', async () => {
+    const token = jwt.sign({ role: 'Doctor' }, 'changeme', { subject: 'u1' });
+    await request(app).get('/api/patients').set('Authorization', `Bearer ${token}`).query({ query: 'a' });
+    await request(app).get('/api/patients').set('Authorization', `Bearer ${token}`).query({ query: 'a' });
+    const res = await request(app)
+      .get('/api/patients')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ query: 'a' });
+    expect(res.status).toBe(429);
+  });
+});
+
+describe('CORS in production', () => {
+  it('disables cors in production', async () => {
+    jest.resetModules();
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = 'changeme';
+    const mod = await import('../src/index');
+    const res = await request(mod.app).get('/api/health');
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- enforce helmet protections, disable x-powered-by, and require sslmode in DATABASE_URL
- add zod-based request validator and sanitized error handling
- rate-limit auth and patient search endpoints with tests for headers, limits, and CORS

## Testing
- `npm test` *(fails: jest: not found / dependency install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68beb52084bc832ea8c1460a35b937b1