### PR TITLE
Add auth context and HTTP wrapper with token refresh

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,11 +1,21 @@
 import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
+import Login from './pages/Login';
+import RouteGuard from './components/RouteGuard';
 import './styles/App.css';
 
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
+      <Route path="/login" element={<Login />} />
+      <Route
+        path="/"
+        element={
+          <RouteGuard>
+            <Home />
+          </RouteGuard>
+        }
+      />
     </Routes>
   );
 }

--- a/client/src/api/http.ts
+++ b/client/src/api/http.ts
@@ -1,0 +1,53 @@
+let accessToken: string | null = null;
+let listeners: Array<(token: string | null) => void> = [];
+
+export function getAccessToken() {
+  return accessToken;
+}
+
+export function setAccessToken(token: string | null) {
+  accessToken = token;
+  listeners.forEach((cb) => cb(token));
+}
+
+export function subscribeAccessToken(cb: (token: string | null) => void) {
+  listeners.push(cb);
+  return () => {
+    listeners = listeners.filter((fn) => fn !== cb);
+  };
+}
+
+export async function fetchJSON(
+  path: string,
+  options: RequestInit = {},
+  retry = true,
+) {
+  const headers = new Headers(options.headers || {});
+  if (accessToken) headers.set('Authorization', `Bearer ${accessToken}`);
+
+  const response = await fetch(`/api${path}`, { ...options, headers });
+
+  if (response.status === 401 && retry) {
+    const refreshRes = await fetch('/api/auth/token/refresh', {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (refreshRes.ok) {
+      const refreshData = await refreshRes.json();
+      setAccessToken(refreshData.accessToken);
+      headers.set('Authorization', `Bearer ${refreshData.accessToken}`);
+      const retryRes = await fetch(`/api${path}`, { ...options, headers });
+      if (!retryRes.ok) {
+        const errText = await retryRes.text();
+        throw new Error(errText || retryRes.statusText);
+      }
+      return retryRes.json();
+    }
+  }
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(errText || response.statusText);
+  }
+  return response.json();
+}

--- a/client/src/components/RouteGuard.tsx
+++ b/client/src/components/RouteGuard.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthProvider';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function RouteGuard({ children }: Props) {
+  const { accessToken } = useAuth();
+  const location = useLocation();
+  if (!accessToken) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+  return <>{children}</>;
+}

--- a/client/src/context/AuthProvider.tsx
+++ b/client/src/context/AuthProvider.tsx
@@ -1,0 +1,63 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import {
+  fetchJSON,
+  getAccessToken,
+  setAccessToken,
+  subscribeAccessToken,
+} from '../api/http';
+
+interface User {
+  userId: string;
+  role: string;
+  email: string;
+}
+
+interface AuthContextType {
+  accessToken: string | null;
+  user: User | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [accessToken, setAccessTokenState] = useState<string | null>(
+    getAccessToken(),
+  );
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = subscribeAccessToken(setAccessTokenState);
+    return unsubscribe;
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const data = await fetchJSON('/auth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    setAccessToken(data.accessToken);
+    setUser({ userId: data.userId, role: data.role, email: data.email });
+  };
+
+  const logout = () => {
+    setAccessToken(null);
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ accessToken, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './styles/index.css';
+import { AuthProvider } from './context/AuthProvider';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthProvider';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as any)?.from?.pathname || '/';
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await login(email, password);
+    navigate(from, { replace: true });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit">Login</button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add fetchJSON wrapper that prefixes /api, attaches bearer token, and refreshes tokens on 401
- provide AuthProvider with login/logout and memory-stored user state
- protect routes via RouteGuard and add simple login page

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npx jest` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: missing eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcada2ec0832eaf6847e9b43a032e