### PR TITLE
feat: add login page and auth flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import RouteGuard from './components/RouteGuard';
@@ -9,13 +9,14 @@ function App() {
     <Routes>
       <Route path="/login" element={<Login />} />
       <Route
-        path="/"
+        path="/patients"
         element={
           <RouteGuard>
             <Home />
           </RouteGuard>
         }
       />
+      <Route path="/" element={<Navigate to="/patients" replace />} />
     </Routes>
   );
 }

--- a/client/src/context/AuthProvider.tsx
+++ b/client/src/context/AuthProvider.tsx
@@ -35,13 +35,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const login = async (email: string, password: string) => {
-    const data = await fetchJSON('/auth/token', {
+    const data = await fetchJSON('/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password }),
     });
     setAccessToken(data.accessToken);
-    setUser({ userId: data.userId, role: data.role, email: data.email });
+    const payload: { sub: string; role: string } = JSON.parse(
+      atob(data.accessToken.split('.')[1]),
+    );
+    setUser({ userId: payload.sub, role: payload.role, email });
   };
 
   const logout = () => {

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,23 +1,28 @@
 import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthProvider';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
   const { login } = useAuth();
   const navigate = useNavigate();
-  const location = useLocation();
-  const from = (location.state as any)?.from?.pathname || '/';
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await login(email, password);
-    navigate(from, { replace: true });
+    setError(null);
+    try {
+      await login(email, password);
+      navigate('/patients');
+    } catch (err: any) {
+      setError(err.message);
+    }
   };
 
   return (
     <form onSubmit={handleSubmit}>
+      {error && <p>{error}</p>}
       <input
         placeholder="Email"
         value={email}


### PR DESCRIPTION
## Summary
- implement login page calling /api/auth/login and show server errors
- store JWT in AuthProvider and send users to /patients
- add /login and /patients routes in App router

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcc2b4374832ea939300f5b2a31be