### PR TITLE
Add patient search UI with navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,8 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
-import Home from './pages/Home';
 import Login from './pages/Login';
 import RouteGuard from './components/RouteGuard';
+import Patients from './pages/Patients';
+import PatientDetail from './pages/PatientDetail';
 import './styles/App.css';
 
 function App() {
@@ -12,7 +13,15 @@ function App() {
         path="/patients"
         element={
           <RouteGuard>
-            <Home />
+            <Patients />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/patients/:id"
+        element={
+          <RouteGuard>
+            <PatientDetail />
           </RouteGuard>
         }
       />

--- a/client/src/components/PatientSearch.tsx
+++ b/client/src/components/PatientSearch.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchJSON } from '../api/http';
+
+interface Patient {
+  patientId: string;
+  name: string;
+  dob: string;
+  insurance: string | null;
+}
+
+export default function PatientSearch() {
+  const [query, setQuery] = useState('');
+  const [debounced, setDebounced] = useState('');
+  const [results, setResults] = useState<Patient[]>([]);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(query), 300);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  useEffect(() => {
+    async function search() {
+      if (!debounced) {
+        setResults([]);
+        return;
+      }
+      try {
+        const data = await fetchJSON(`/patients?query=${encodeURIComponent(debounced)}`);
+        setResults(data);
+      } catch (err) {
+        console.error(err);
+        setResults([]);
+      }
+    }
+    search();
+  }, [debounced]);
+
+  return (
+    <div>
+      <input
+        placeholder="Search patients"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>DOB</th>
+            <th>Insurance</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {results.map((p) => (
+            <tr key={p.patientId}>
+              <td>{p.name}</td>
+              <td>{new Date(p.dob).toLocaleDateString()}</td>
+              <td>{p.insurance || ''}</td>
+              <td>
+                <Link to={`/patients/${p.patientId}`}>View</Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchJSON } from '../api/http';
+
+interface Patient {
+  patientId: string;
+  name: string;
+  dob: string;
+  insurance: string | null;
+}
+
+export default function PatientDetail() {
+  const { id } = useParams<{ id: string }>();
+  const [patient, setPatient] = useState<Patient | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      if (!id) return;
+      try {
+        const data = await fetchJSON(`/patients/${id}`);
+        setPatient(data);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, [id]);
+
+  if (!patient) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>{patient.name}</h1>
+      <p>DOB: {new Date(patient.dob).toLocaleDateString()}</p>
+      <p>Insurance: {patient.insurance || ''}</p>
+    </div>
+  );
+}

--- a/client/src/pages/Patients.tsx
+++ b/client/src/pages/Patients.tsx
@@ -1,0 +1,10 @@
+import PatientSearch from '../components/PatientSearch';
+
+export default function Patients() {
+  return (
+    <div>
+      <h1>Patients</h1>
+      <PatientSearch />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add patient search component with debounced query and results table
- wire up Patients page and patient detail view with routing

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcdbada9c832e8a35fe2c25f135aa