### PR TITLE
feat: add typed api client

### DIFF
--- a/client/src/components/PatientSearch.tsx
+++ b/client/src/components/PatientSearch.tsx
@@ -1,13 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { fetchJSON } from '../api/http';
-
-interface Patient {
-  patientId: string;
-  name: string;
-  dob: string;
-  insurance: string | null;
-}
+import { searchPatients, type Patient } from '../api/client';
 
 export default function PatientSearch() {
   const [query, setQuery] = useState('');
@@ -26,7 +19,7 @@ export default function PatientSearch() {
         return;
       }
       try {
-        const data = await fetchJSON(`/patients?query=${encodeURIComponent(debounced)}`);
+        const data = await searchPatients(debounced);
         setResults(data);
       } catch (err) {
         console.error(err);

--- a/client/src/context/AuthProvider.tsx
+++ b/client/src/context/AuthProvider.tsx
@@ -1,10 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import {
-  fetchJSON,
-  getAccessToken,
-  setAccessToken,
-  subscribeAccessToken,
-} from '../api/http';
+import { getAccessToken, setAccessToken, subscribeAccessToken } from '../api/http';
+import { login as apiLogin, type Tokens } from '../api/client';
 
 interface User {
   userId: string;
@@ -35,11 +31,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const login = async (email: string, password: string) => {
-    const data = await fetchJSON('/auth/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
-    });
+    const data: Tokens = await apiLogin(email, password);
     setAccessToken(data.accessToken);
     const payload: { sub: string; role: string } = JSON.parse(
       atob(data.accessToken.split('.')[1]),

--- a/client/src/pages/Cohort.tsx
+++ b/client/src/pages/Cohort.tsx
@@ -1,15 +1,5 @@
 import { useState } from 'react';
-import { fetchJSON } from '../api/http';
-
-interface CohortResult {
-  patientId: string;
-  name: string;
-  lastMatchingLab: {
-    value: number;
-    date: string;
-    visitId: string;
-  };
-}
+import { cohort, type CohortResult } from '../api/client';
 
 export default function Cohort() {
   const [testName, setTestName] = useState('');
@@ -25,13 +15,12 @@ export default function Cohort() {
     setError(null);
     setLoading(true);
     try {
-      const params = new URLSearchParams({
+      const data = await cohort({
         test_name: testName,
-        op,
-        value,
-        months,
+        op: op as any,
+        value: parseFloat(value),
+        months: parseInt(months, 10),
       });
-      const data = await fetchJSON(`/insights/cohort?${params.toString()}`);
       setResults(data);
     } catch (err: any) {
       setError(err.message || 'Failed to load cohort');

--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -1,59 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { fetchJSON } from '../api/http';
-
-interface Diagnosis {
-  diagnosis: string;
-}
-
-interface Medication {
-  drugName: string;
-  dosage?: string;
-  instructions?: string;
-}
-
-interface LabResult {
-  testName: string;
-  resultValue: number | null;
-  unit: string | null;
-  testDate: string | null;
-}
-
-interface Observation {
-  obsId: string;
-  noteText: string;
-  bpSystolic?: number;
-  bpDiastolic?: number;
-  heartRate?: number;
-  temperatureC?: number;
-  spo2?: number;
-  bmi?: number;
-  createdAt: string;
-}
-
-interface VisitSummary {
-  visitId: string;
-  visitDate: string;
-  diagnoses: Diagnosis[];
-  medications: Medication[];
-  labResults: LabResult[];
-  observations: Observation[];
-}
-
-interface PatientSummary {
-  patientId: string;
-  name: string;
-  dob: string;
-  insurance: string | null;
-  visits: VisitSummary[];
-}
-
-interface Visit {
-  visitId: string;
-  visitDate: string;
-  department: string;
-  reason?: string;
-}
+import {
+  getPatient,
+  listPatientVisits,
+  type PatientSummary,
+  type Visit,
+} from '../api/client';
 
 export default function PatientDetail() {
   const { id } = useParams<{ id: string }>();
@@ -66,8 +18,8 @@ export default function PatientDetail() {
     async function load() {
       if (!id) return;
       try {
-        const data = await fetchJSON(`/patients/${id}?include=summary`);
-        setPatient(data);
+        const data = await getPatient(id, { include: 'summary' });
+        setPatient(data as PatientSummary);
       } catch (err) {
         console.error(err);
       }
@@ -80,7 +32,7 @@ export default function PatientDetail() {
       if (activeTab !== 'visits' || !id || visits) return;
       setVisitsLoading(true);
       try {
-        const data = await fetchJSON(`/patients/${id}/visits`);
+        const data = await listPatientVisits(id);
         setVisits(data);
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- add typed API client generated from OpenAPI schema
- refactor pages and auth provider to use typed client methods

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd0c5b2dc832eb15efe127637c958