### PR TITLE
style: redesign login page

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -6,14 +6,17 @@ export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
   const { login } = useAuth();
   const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setSuccess(null);
     try {
       await login(email, password);
+      setSuccess('Login successful');
       navigate('/patients');
     } catch (err: any) {
       setError(err.message);
@@ -21,20 +24,85 @@ export default function Login() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      {error && <p>{error}</p>}
-      <input
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <input
-        type="password"
-        placeholder="Password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      <button type="submit">Login</button>
-    </form>
+    <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+      <div className="w-full max-w-sm rounded-2xl bg-white p-8 shadow-xl">
+        <div className="flex flex-col items-center">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className="mb-4 h-12 w-12 text-blue-600"
+          >
+            <path d="M12 2a1 1 0 0 1 .993.883L13 3v1h1a1 1 0 0 1 .117 1.993L14 6h-1v1a1 1 0 0 1-1.993.117L11 7V6h-1a1 1 0 0 1-.117-1.993L10 4h1V3a1 1 0 0 1 1-1z" />
+            <path d="M6 8a1 1 0 0 1 .117 1.993L6 10H5v10h14V10h-1a1 1 0 0 1-.117-1.993L18 8h2a1 1 0 0 1 .993.883L21 9v12a1 1 0 0 1-.883.993L20 22H4a1 1 0 0 1-.993-.883L3 21V9a1 1 0 0 1 .883-.993L4 8h2z" />
+          </svg>
+          <h1 className="text-2xl font-bold text-gray-900">EMR System</h1>
+          <h2 className="mt-2 text-sm text-gray-600">Sign in to your account</h2>
+        </div>
+        {error && (
+          <div className="mt-4 rounded-md bg-red-100 p-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+        {success && (
+          <div className="mt-4 rounded-md bg-green-100 p-2 text-sm text-green-700">
+            {success}
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className="mt-6">
+          <div className="mb-4">
+            <label
+              htmlFor="email"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              placeholder="you@example.com"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+          <div className="mb-4">
+            <label
+              htmlFor="password"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              placeholder="••••••••"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          <div className="mb-6 flex items-center">
+            <input
+              id="remember"
+              type="checkbox"
+              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <label
+              htmlFor="remember"
+              className="ml-2 block text-sm text-gray-700"
+            >
+              Remember me
+            </label>
+          </div>
+          <button
+            type="submit"
+            className="w-full rounded-md bg-blue-600 px-3 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            Login
+          </button>
+        </form>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- restyle login form with Tailwind card layout and icon
- add styled error and success messages with remember-me option

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdc576f38832eba7aad62e6e192cc