### PR TITLE
fix(login): proxy API requests during development

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,6 +3,15 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   build: { outDir: '../dist_client' },
-  server: { port: 5173 },
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- proxy `/api` to backend in Vite dev server

## Testing
- `npm test` *(fails: Cannot find module '/workspace/EMR/node_modules/jest/bin/jest.js')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68bffc305348832e8a7a0ab31d47eb51