### PR TITLE
feat: share login layout across pages

### DIFF
--- a/client/src/components/PageLayout.tsx
+++ b/client/src/components/PageLayout.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface PageLayoutProps {
+  children: React.ReactNode;
+  maxWidth?: string;
+}
+
+export default function PageLayout({ children, maxWidth = 'max-w-2xl' }: PageLayoutProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+      <div className={`w-full ${maxWidth} rounded-2xl bg-white p-8 shadow`}>{children}</div>
+    </div>
+  );
+}

--- a/client/src/pages/Cohort.tsx
+++ b/client/src/pages/Cohort.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { cohort, type CohortResult } from '../api/client';
+import PageLayout from '../components/PageLayout';
 
 export default function Cohort() {
   const [testName, setTestName] = useState('');
@@ -30,7 +31,7 @@ export default function Cohort() {
   }
 
   return (
-    <div>
+    <PageLayout>
       <h1>Cohort Insights</h1>
       <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
         <div>
@@ -111,7 +112,7 @@ export default function Cohort() {
           </tbody>
         </table>
       )}
-    </div>
+    </PageLayout>
   );
 }
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,3 +1,9 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Home() {
-  return <h1>Home</h1>;
+  return (
+    <PageLayout>
+      <h1>Home</h1>
+    </PageLayout>
+  );
 }

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthProvider';
 import LoginCard from '../components/LoginCard';
+import PageLayout from '../components/PageLayout';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -33,20 +34,18 @@ export default function Login() {
   const values = { username: email, password };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
-      <div className="w-full max-w-sm">
-        {error && (
-          <div className="mb-4 rounded-md bg-red-100 p-2 text-sm text-red-700">
-            {error}
-          </div>
-        )}
-        {success && (
-          <div className="mb-4 rounded-md bg-green-100 p-2 text-sm text-green-700">
-            {success}
-          </div>
-        )}
-        <LoginCard onSubmit={handleSubmit} values={values} onChange={handleChange} />
-      </div>
-    </div>
+    <PageLayout maxWidth="max-w-sm">
+      {error && (
+        <div className="mb-4 rounded-md bg-red-100 p-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="mb-4 rounded-md bg-green-100 p-2 text-sm text-green-700">
+          {success}
+        </div>
+      )}
+      <LoginCard onSubmit={handleSubmit} values={values} onChange={handleChange} />
+    </PageLayout>
   );
 }

--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -6,6 +6,7 @@ import {
   type PatientSummary,
   type Visit,
 } from '../api/client';
+import PageLayout from '../components/PageLayout';
 
 export default function PatientDetail() {
   const { id } = useParams<{ id: string }>();
@@ -43,7 +44,12 @@ export default function PatientDetail() {
     loadVisits();
   }, [activeTab, id, visits]);
 
-  if (!patient) return <div>Loading...</div>;
+  if (!patient)
+    return (
+      <PageLayout>
+        <div>Loading...</div>
+      </PageLayout>
+    );
 
   function renderSummary() {
     if (!patient.visits || patient.visits.length === 0) {
@@ -119,7 +125,7 @@ export default function PatientDetail() {
   }
 
   return (
-    <div>
+    <PageLayout>
       <h1>{patient.name}</h1>
       <p>DOB: {new Date(patient.dob).toLocaleDateString()}</p>
       <p>Insurance: {patient.insurance || ''}</p>
@@ -141,7 +147,7 @@ export default function PatientDetail() {
         </button>
       </div>
       {activeTab === 'summary' ? renderSummary() : renderVisits()}
-    </div>
+    </PageLayout>
   );
 }
 

--- a/client/src/pages/Patients.tsx
+++ b/client/src/pages/Patients.tsx
@@ -1,10 +1,11 @@
 import PatientSearch from '../components/PatientSearch';
+import PageLayout from '../components/PageLayout';
 
 export default function Patients() {
   return (
-    <div>
+    <PageLayout>
       <h1>Patients</h1>
       <PatientSearch />
-    </div>
+    </PageLayout>
   );
 }

--- a/client/src/pages/VisitDetail.tsx
+++ b/client/src/pages/VisitDetail.tsx
@@ -8,6 +8,7 @@ import {
   type Observation,
   type AddObservationPayload,
 } from '../api/client';
+import PageLayout from '../components/PageLayout';
 
 export default function VisitDetail() {
   const { id } = useParams<{ id: string }>();
@@ -88,10 +89,15 @@ export default function VisitDetail() {
     }
   }
 
-  if (loading || !visit) return <div>Loading...</div>;
+  if (loading || !visit)
+    return (
+      <PageLayout>
+        <div>Loading...</div>
+      </PageLayout>
+    );
 
   return (
-    <div>
+    <PageLayout>
       <h1>Visit Detail</h1>
       <p>Date: {new Date(visit.visitDate).toLocaleDateString()}</p>
       <p>Department: {visit.department}</p>
@@ -236,7 +242,7 @@ export default function VisitDetail() {
           )}
         </div>
       )}
-    </div>
+    </PageLayout>
   );
 }
 


### PR DESCRIPTION
## Summary
- add reusable PageLayout component to centralize background and card styling
- apply PageLayout to login, patients, patient and visit detail, cohort, and home pages

## Testing
- `npm test` *(fails: Cannot find module '/workspace/EMR/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c00eaa6264832ea84d38aa0ee70e40