### PR TITLE
fix: remove autoprefixer plugin

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,6 @@
     "typescript": "^5.2.2",
     "vite": "^5.0.0",
     "tailwindcss": "^4.1.13",
-    "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.16"
+    "postcss": "^8.4.31"
   }
 }

--- a/client/postcss.config.cjs
+++ b/client/postcss.config.cjs
@@ -1,6 +1,5 @@
 module.exports = {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- remove autoprefixer from client PostCSS config and devDependencies to prevent runtime failure

## Testing
- `npm test` *(fails: Could not find a declaration file for module 'bcrypt'; Property 'find' does not exist on type 'string'; Could not find a declaration file for module 'jsonwebtoken'; Could not find a declaration file for module 'express'; Could not find a declaration file for module 'cors'; Could not find a declaration file for module 'morgan'; Parameter '_req' implicitly has an 'any' type; Parameter 'res' implicitly has an 'any' type; Parameter 'req' implicitly has an 'any' type; Parameter 'res' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68c014187874832eb15f700cc099e16a