### PR TITLE
Fix Tailwind content configuration for client build

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [],
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+    "../packages/ui/**/*.{js,ts,jsx,tsx}",
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- configure Tailwind `content` paths in `client/tailwind.config.js` so styles are generated

## Testing
- `npm test` (fails: Could not find a declaration file for module 'bcrypt'. tests...)
- `npm run lint` (fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)

------
https://chatgpt.com/codex/tasks/task_e_68c044b886ac832eb3c5d31a2118001b