### PR TITLE
style: improve patient detail layout

### DIFF
--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -6,7 +6,6 @@ import {
   type PatientSummary,
   type Visit,
 } from '../api/client';
-import PageLayout from '../components/PageLayout';
 
 export default function PatientDetail() {
   const { id } = useParams<{ id: string }>();
@@ -46,108 +45,153 @@ export default function PatientDetail() {
 
   if (!patient)
     return (
-      <PageLayout>
+      <div className="mx-auto max-w-4xl p-4 md:p-6">
         <div>Loading...</div>
-      </PageLayout>
+      </div>
     );
 
   function renderSummary() {
     if (!patient.visits || patient.visits.length === 0) {
-      return <div>No visit history.</div>;
+      return <div className="mt-6">No visit history.</div>;
     }
     return (
-      <div>
+      <div className="mt-6 space-y-5">
         {patient.visits.map((visit) => (
-          <div
+          <section
             key={visit.visitId}
-            style={{ border: '1px solid #ccc', padding: '0.5rem', marginBottom: '0.5rem' }}
+            className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
           >
-            <h3>Visit on {new Date(visit.visitDate).toLocaleDateString()}</h3>
-            {visit.diagnoses.length > 0 && (
-              <p>Diagnoses: {visit.diagnoses.map((d) => d.diagnosis).join(', ')}</p>
-            )}
-            {visit.medications.length > 0 && (
-              <p>
-                Medications:{' '}
-                {visit.medications
-                  .map((m) => (m.dosage ? `${m.drugName} (${m.dosage})` : m.drugName))
-                  .join(', ')}
-              </p>
-            )}
-            {visit.labResults.length > 0 && (
-              <p>
-                Labs:{' '}
-                {visit.labResults
-                  .map((l) => `${l.testName} ${l.resultValue ?? ''}${l.unit ?? ''}`)
-                  .join(', ')}
-              </p>
-            )}
-            {visit.observations.length > 0 && (
-              <p>
-                Observations:{' '}
-                {visit.observations.map((o) => o.noteText).join('; ')}
-              </p>
-            )}
-          </div>
+            <h3 className="text-base font-semibold text-gray-900">
+              Visit on {new Date(visit.visitDate).toLocaleDateString()}
+            </h3>
+            <div className="mt-3 space-y-2 text-sm text-gray-700">
+              {visit.diagnoses.length > 0 && (
+                <p>
+                  <span className="font-semibold">Diagnoses:</span>{' '}
+                  {visit.diagnoses.map((d) => d.diagnosis).join(', ')}
+                </p>
+              )}
+              {visit.medications.length > 0 && (
+                <p>
+                  <span className="font-semibold">Medications:</span>{' '}
+                  {visit.medications
+                    .map((m) =>
+                      m.dosage ? `${m.drugName} (${m.dosage})` : m.drugName,
+                    )
+                    .join(', ')}
+                </p>
+              )}
+              {visit.labResults.length > 0 && (
+                <p>
+                  <span className="font-semibold">Labs:</span>{' '}
+                  {visit.labResults
+                    .map(
+                      (l) =>
+                        `${l.testName} ${l.resultValue ?? ''}${l.unit ?? ''}`,
+                    )
+                    .join(', ')}
+                </p>
+              )}
+              {visit.observations.length > 0 && (
+                <p>
+                  <span className="font-semibold">Observations:</span>{' '}
+                  {visit.observations.map((o) => o.noteText).join('; ')}
+                </p>
+              )}
+            </div>
+          </section>
         ))}
       </div>
     );
   }
 
   function renderVisits() {
-    if (visitsLoading) return <div>Loading visits...</div>;
+    if (visitsLoading) return <div className="mt-6">Loading visits...</div>;
     if (!visits) return null;
-    if (visits.length === 0) return <div>No visits found.</div>;
+    if (visits.length === 0) return <div className="mt-6">No visits found.</div>;
     return (
-      <table style={{ borderCollapse: 'collapse', width: '100%' }}>
-        <thead>
-          <tr>
-            <th style={{ borderBottom: '1px solid #ccc', textAlign: 'left' }}>Date</th>
-            <th style={{ borderBottom: '1px solid #ccc', textAlign: 'left' }}>Department</th>
-            <th style={{ borderBottom: '1px solid #ccc', textAlign: 'left' }}>Reason</th>
-            <th style={{ borderBottom: '1px solid #ccc' }}></th>
-          </tr>
-        </thead>
-        <tbody>
-          {visits.map((v) => (
-            <tr key={v.visitId}>
-              <td style={{ padding: '0.25rem 0' }}>{new Date(v.visitDate).toLocaleDateString()}</td>
-              <td style={{ padding: '0.25rem 0' }}>{v.department}</td>
-              <td style={{ padding: '0.25rem 0' }}>{v.reason || ''}</td>
-              <td style={{ padding: '0.25rem 0' }}>
-                <Link to={`/visits/${v.visitId}`}>View</Link>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className="mt-6 space-y-5">
+        {visits.map((v) => (
+          <section
+            key={v.visitId}
+            className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
+          >
+            <h3 className="text-base font-semibold text-gray-900">
+              Visit on {new Date(v.visitDate).toLocaleDateString()}
+            </h3>
+            <div className="mt-3 space-y-2 text-sm text-gray-700">
+              <p>
+                <span className="font-semibold">Department:</span> {v.department}
+              </p>
+              {v.reason && (
+                <p>
+                  <span className="font-semibold">Reason:</span> {v.reason}
+                </p>
+              )}
+              <p>
+                <Link
+                  to={`/visits/${v.visitId}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  View
+                </Link>
+              </p>
+            </div>
+          </section>
+        ))}
+      </div>
     );
   }
 
   return (
-    <PageLayout>
-      <h1>{patient.name}</h1>
-      <p>DOB: {new Date(patient.dob).toLocaleDateString()}</p>
-      <p>Insurance: {patient.insurance || ''}</p>
-      <div style={{ marginTop: '1rem', marginBottom: '1rem' }}>
-        <button
-          onClick={() => setActiveTab('summary')}
-          style={{
-            marginRight: '1rem',
-            fontWeight: activeTab === 'summary' ? 'bold' : undefined,
-          }}
-        >
-          Summary
-        </button>
-        <button
-          onClick={() => setActiveTab('visits')}
-          style={{ fontWeight: activeTab === 'visits' ? 'bold' : undefined }}
-        >
-          Visits
-        </button>
+    <div className="mx-auto max-w-4xl p-4 md:p-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-gray-900">
+          {patient.name}
+        </h1>
+        <p className="mt-1 text-sm text-gray-700">
+          <span className="font-semibold">DOB:</span>{' '}
+          {new Date(patient.dob).toLocaleDateString()}
+        </p>
+        <p className="mt-1 text-sm text-gray-700">
+          <span className="font-semibold">Insurance:</span>{' '}
+          {patient.insurance || ''}
+        </p>
       </div>
+
+      <div className="mt-6 border-b border-gray-200">
+        <nav role="tablist" className="flex gap-6">
+          <button
+            role="tab"
+            aria-selected={activeTab === 'summary'}
+            onClick={() => setActiveTab('summary')}
+            className={
+              '-mb-px px-1 pb-3 text-sm font-medium focus:outline-none ' +
+              (activeTab === 'summary'
+                ? 'text-blue-600 border-b-2 border-blue-600'
+                : 'text-gray-600 hover:text-gray-800 border-b-2 border-transparent hover:border-gray-300')
+            }
+          >
+            Summary
+          </button>
+          <button
+            role="tab"
+            aria-selected={activeTab === 'visits'}
+            onClick={() => setActiveTab('visits')}
+            className={
+              '-mb-px px-1 pb-3 text-sm font-medium focus:outline-none ' +
+              (activeTab === 'visits'
+                ? 'text-blue-600 border-b-2 border-blue-600'
+                : 'text-gray-600 hover:text-gray-800 border-b-2 border-transparent hover:border-gray-300')
+            }
+          >
+            Visits
+          </button>
+        </nav>
+      </div>
+
       {activeTab === 'summary' ? renderSummary() : renderVisits()}
-    </PageLayout>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- restyle patient header with larger name and metadata labels
- implement accessible tab bar with active styling
- render visit summaries in card layout with bold labels

## Testing
- `npm test` *(fails: Could not find a declaration file for module 'jsonwebtoken')*
- `npm install --save-dev @types/bcrypt @types/jsonwebtoken` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fbcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68c05a041b24832ea6e313264bcfedcf