### PR TITLE
Add navigation buttons to pages

### DIFF
--- a/client/src/components/NavigationButtons.tsx
+++ b/client/src/components/NavigationButtons.tsx
@@ -1,0 +1,24 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function NavigationButtons() {
+  const navigate = useNavigate();
+  return (
+    <div className="mt-4 flex justify-between">
+      <button
+        type="button"
+        onClick={() => navigate(-1)}
+        className="rounded bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300"
+      >
+        Back
+      </button>
+      <button
+        type="button"
+        onClick={() => navigate(1)}
+        className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+      >
+        Next
+      </button>
+    </div>
+  );
+}
+

--- a/client/src/components/PatientSearch.tsx
+++ b/client/src/components/PatientSearch.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { searchPatients, type Patient } from '../api/client';
+import NavigationButtons from './NavigationButtons';
 
 export default function PatientSearch() {
   const [query, setQuery] = useState('');
@@ -90,6 +91,7 @@ export default function PatientSearch() {
             </tbody>
           </table>
         </div>
+        <NavigationButtons />
       </div>
     </div>
   );

--- a/client/src/pages/Cohort.tsx
+++ b/client/src/pages/Cohort.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { cohort, type CohortResult } from '../api/client';
 import PageLayout from '../components/PageLayout';
+import NavigationButtons from '../components/NavigationButtons';
 
 export default function Cohort() {
   const [testName, setTestName] = useState('');
@@ -112,6 +113,7 @@ export default function Cohort() {
           </tbody>
         </table>
       )}
+      <NavigationButtons />
     </PageLayout>
   );
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,9 +1,11 @@
 import PageLayout from '../components/PageLayout';
+import NavigationButtons from '../components/NavigationButtons';
 
 export default function Home() {
   return (
     <PageLayout>
       <h1>Home</h1>
+      <NavigationButtons />
     </PageLayout>
   );
 }

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthProvider';
 import LoginCard from '../components/LoginCard';
 import PageLayout from '../components/PageLayout';
+import NavigationButtons from '../components/NavigationButtons';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -46,6 +47,7 @@ export default function Login() {
         </div>
       )}
       <LoginCard onSubmit={handleSubmit} values={values} onChange={handleChange} />
+      <NavigationButtons />
     </PageLayout>
   );
 }

--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import NavigationButtons from '../components/NavigationButtons';
 import {
   getPatient,
   listPatientVisits,
@@ -198,6 +199,7 @@ export default function PatientDetail() {
         </div>
 
         {activeTab === 'summary' ? renderSummary() : renderVisits()}
+        <NavigationButtons />
       </div>
     </div>
   );

--- a/client/src/pages/VisitDetail.tsx
+++ b/client/src/pages/VisitDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import NavigationButtons from '../components/NavigationButtons';
 import {
   addObservation,
   getPatient,
@@ -199,6 +200,7 @@ export default function VisitDetail() {
         <p className="mt-4 text-sm text-gray-500">
           My previous notes for this patient (before this visit)
         </p>
+        <NavigationButtons />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- introduce NavigationButtons component for consistent previous/next controls
- embed navigation controls across Home, Login, Cohort, PatientDetail, VisitDetail, and PatientSearch pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: missing TypeScript declaration files for dependencies such as bcrypt and jsonwebtoken)*

------
https://chatgpt.com/codex/tasks/task_e_68c063fab4c8832e84ffd4525e19c069