### PR TITLE
fix: guard against null patient in details page

### DIFF
--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -53,13 +53,13 @@ export default function PatientDetail() {
       </div>
     );
 
-  function renderSummary() {
-    if (!patient.visits || patient.visits.length === 0) {
+  function renderSummary(p: PatientSummary) {
+    if (!p.visits || p.visits.length === 0) {
       return <div className="mt-6">No visit history.</div>;
     }
     return (
       <div className="mt-5 space-y-5">
-        {patient.visits.map((visit) => (
+        {p.visits.map((visit) => (
           <section
             key={visit.visitId}
             className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
@@ -198,7 +198,7 @@ export default function PatientDetail() {
           </nav>
         </div>
 
-        {activeTab === 'summary' ? renderSummary() : renderVisits()}
+          {activeTab === 'summary' ? renderSummary(patient) : renderVisits()}
         <NavigationButtons />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- pass PatientSummary into renderSummary to avoid null patient errors
- render patient visit history safely

## Testing
- `npm test` *(fails: Cannot find module './server.js' from 'src/index.ts')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `cd client && npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68c067a6ea84832e8b5af77b61941226