### PR TITLE
Build server on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Atenxion EMR is a reference implementation of an electronic medical record syste
    ```
    The API runs on `http://localhost:8080` and the web client on `http://localhost:5173`.
 
+3. To run the API without watch mode, start the compiled server:
+   ```bash
+   npm start
+   ```
+   This command compiles the TypeScript API before launching.
+
 ## Neon PostgreSQL Setup
 Provision a PostgreSQL instance on [Neon](https://neon.tech) and set the `DATABASE_URL` and `DIRECT_URL` in `.env` (include `sslmode=require` for both). Enable the required extensions:
 ```sql

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && cd client && npm install && npm run build",
-    "start": "node dist/index.js",
+    "build": "npm run build:server && npm run build:client",
+    "build:server": "tsc",
+    "build:client": "cd client && npm install && npm run build",
+    "prestart": "npm run build:server",
+    "start": "node dist/src/index.js",
     "dev": "concurrently -k -n API,WEB \"tsx watch src/index.ts\" \"cd client && npm run dev\"",
     "dev:api": "tsx watch src/index.ts",
     "dev:web": "cd client && npm run dev",


### PR DESCRIPTION
## Summary
- ensure TypeScript sources compile before starting the API
- document how to start the compiled server without watch mode

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test` *(fails: Cannot find module './server.js' from 'src/index.ts')*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68c069df9750832e9750ef5e309749df