### PR TITLE
feat: add visit creation page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import RouteGuard from './components/RouteGuard';
 import Patients from './pages/Patients';
 import PatientDetail from './pages/PatientDetail';
 import VisitDetail from './pages/VisitDetail';
+import AddVisit from './pages/AddVisit';
 import Cohort from './pages/Cohort';
 import './styles/App.css';
 
@@ -24,6 +25,14 @@ function App() {
         element={
           <RouteGuard>
             <PatientDetail />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/patients/:id/visits/new"
+        element={
+          <RouteGuard>
+            <AddVisit />
           </RouteGuard>
         }
       />

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -108,6 +108,73 @@ export async function getVisit(id: string): Promise<VisitDetail> {
   return fetchJSON(`/visits/${id}`);
 }
 
+export interface CreateVisitPayload {
+  patientId: string;
+  visitDate: string;
+  doctorId: string;
+  department: string;
+  reason?: string;
+}
+
+export async function createVisit(payload: CreateVisitPayload): Promise<Visit> {
+  return fetchJSON('/visits', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export interface AddDiagnosisPayload {
+  diagnosis: string;
+}
+
+export async function addDiagnosis(
+  visitId: string,
+  payload: AddDiagnosisPayload,
+): Promise<Diagnosis> {
+  return fetchJSON(`/visits/${visitId}/diagnoses`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export interface AddMedicationPayload {
+  drugName: string;
+  dosage?: string;
+  instructions?: string;
+}
+
+export async function addMedication(
+  visitId: string,
+  payload: AddMedicationPayload,
+): Promise<Medication> {
+  return fetchJSON(`/visits/${visitId}/medications`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export interface AddLabResultPayload {
+  testName: string;
+  resultValue?: number;
+  unit?: string;
+  referenceRange?: string;
+  testDate?: string;
+}
+
+export async function addLabResult(
+  visitId: string,
+  payload: AddLabResultPayload,
+): Promise<LabResult> {
+  return fetchJSON(`/visits/${visitId}/labs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
 export interface AddObservationPayload {
   noteText: string;
   bpSystolic?: number;

--- a/client/src/pages/AddVisit.tsx
+++ b/client/src/pages/AddVisit.tsx
@@ -1,0 +1,275 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import NavigationButtons from '../components/NavigationButtons';
+import {
+  createVisit,
+  addDiagnosis,
+  addMedication,
+  addLabResult,
+  addObservation,
+} from '../api/client';
+import { useAuth } from '../context/AuthProvider';
+
+export default function AddVisit() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const [visitDate, setVisitDate] = useState(
+    new Date().toISOString().slice(0, 10),
+  );
+  const [department, setDepartment] = useState('');
+  const [reason, setReason] = useState('');
+  const [diagnoses, setDiagnoses] = useState('');
+  const [medications, setMedications] = useState('');
+  const [labs, setLabs] = useState('');
+  const [obsNote, setObsNote] = useState('');
+  const [bpSystolic, setBpSystolic] = useState('');
+  const [bpDiastolic, setBpDiastolic] = useState('');
+  const [heartRate, setHeartRate] = useState('');
+  const [temperatureC, setTemperatureC] = useState('');
+  const [spo2, setSpo2] = useState('');
+  const [bmi, setBmi] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!id || !user) return;
+    setSaving(true);
+    try {
+      const visit = await createVisit({
+        patientId: id,
+        visitDate,
+        doctorId: user.userId,
+        department,
+        reason: reason || undefined,
+      });
+      const visitId = visit.visitId;
+
+      const diagList = diagnoses
+        .split('\n')
+        .map((d) => d.trim())
+        .filter(Boolean);
+      for (const d of diagList) {
+        await addDiagnosis(visitId, { diagnosis: d });
+      }
+
+      const medList = medications
+        .split('\n')
+        .map((m) => m.trim())
+        .filter(Boolean);
+      for (const m of medList) {
+        const [drugName, dosage] = m.split('|').map((s) => s.trim());
+        await addMedication(visitId, {
+          drugName,
+          ...(dosage && { dosage }),
+        });
+      }
+
+      const labList = labs
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      for (const l of labList) {
+        const [testName, value, unit] = l.split('|').map((s) => s.trim());
+        await addLabResult(visitId, {
+          testName,
+          ...(value && !isNaN(Number(value)) && { resultValue: Number(value) }),
+          ...(unit && { unit }),
+        });
+      }
+
+      if (
+        obsNote ||
+        bpSystolic ||
+        bpDiastolic ||
+        heartRate ||
+        temperatureC ||
+        spo2 ||
+        bmi
+      ) {
+        await addObservation(visitId, {
+          noteText: obsNote,
+          ...(bpSystolic && { bpSystolic: Number(bpSystolic) }),
+          ...(bpDiastolic && { bpDiastolic: Number(bpDiastolic) }),
+          ...(heartRate && { heartRate: Number(heartRate) }),
+          ...(temperatureC && { temperatureC: Number(temperatureC) }),
+          ...(spo2 && { spo2: Number(spo2) }),
+          ...(bmi && { bmi: Number(bmi) }),
+        });
+      }
+
+      navigate(`/patients/${id}?tab=visits`);
+    } catch (err) {
+      console.error(err);
+      window.alert('Failed to save visit');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="p-4 md:p-6">
+      <div className="mx-auto max-w-3xl rounded-2xl bg-white shadow-xl p-5 md:p-7">
+        <h1 className="text-2xl font-semibold text-gray-900">Add Visit</h1>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Visit Date
+            </label>
+            <input
+              type="date"
+              value={visitDate}
+              onChange={(e) => setVisitDate(e.target.value)}
+              className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Department
+            </label>
+            <input
+              type="text"
+              value={department}
+              onChange={(e) => setDepartment(e.target.value)}
+              className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Reason
+            </label>
+            <input
+              type="text"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Diagnoses (one per line)
+            </label>
+            <textarea
+              value={diagnoses}
+              onChange={(e) => setDiagnoses(e.target.value)}
+              className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              rows={3}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Medications (drug|dosage per line)
+            </label>
+            <textarea
+              value={medications}
+              onChange={(e) => setMedications(e.target.value)}
+              className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              rows={3}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Labs (test|value|unit per line)
+            </label>
+            <textarea
+              value={labs}
+              onChange={(e) => setLabs(e.target.value)}
+              className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              rows={3}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Observation Note
+            </label>
+            <textarea
+              value={obsNote}
+              onChange={(e) => setObsNote(e.target.value)}
+              className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              rows={2}
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                BP Systolic
+              </label>
+              <input
+                type="number"
+                value={bpSystolic}
+                onChange={(e) => setBpSystolic(e.target.value)}
+                className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                BP Diastolic
+              </label>
+              <input
+                type="number"
+                value={bpDiastolic}
+                onChange={(e) => setBpDiastolic(e.target.value)}
+                className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                Heart Rate
+              </label>
+              <input
+                type="number"
+                value={heartRate}
+                onChange={(e) => setHeartRate(e.target.value)}
+                className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                Temp (°C)
+              </label>
+              <input
+                type="number"
+                value={temperatureC}
+                onChange={(e) => setTemperatureC(e.target.value)}
+                className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                SpO2
+              </label>
+              <input
+                type="number"
+                value={spo2}
+                onChange={(e) => setSpo2(e.target.value)}
+                className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">
+                BMI
+              </label>
+              <input
+                type="number"
+                value={bmi}
+                onChange={(e) => setBmi(e.target.value)}
+                className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : 'Save Visit'}
+          </button>
+        </form>
+        <NavigationButtons />
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import NavigationButtons from '../components/NavigationButtons';
 import {
   getPatient,
@@ -10,8 +10,13 @@ import {
 
 export default function PatientDetail() {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const initialTab =
+    new URLSearchParams(location.search).get('tab') === 'visits'
+      ? 'visits'
+      : 'summary';
   const [patient, setPatient] = useState<PatientSummary | null>(null);
-  const [activeTab, setActiveTab] = useState<'summary' | 'visits'>('summary');
+  const [activeTab, setActiveTab] = useState<'summary' | 'visits'>(initialTab);
   const [visits, setVisits] = useState<Visit[] | null>(null);
   const [visitsLoading, setVisitsLoading] = useState(false);
 
@@ -111,41 +116,52 @@ export default function PatientDetail() {
   function renderVisits() {
     if (visitsLoading) return <div className="mt-6">Loading visits...</div>;
     if (!visits) return null;
-    if (visits.length === 0) return <div className="mt-6">No visits found.</div>;
     return (
       <div className="mt-5 space-y-5">
-        {visits.map((v) => (
-          <section
-            key={v.visitId}
-            className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
+        <div className="flex justify-end">
+          <Link
+            to={`/patients/${id}/visits/new`}
+            className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700"
           >
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h3 className="text-base font-semibold text-gray-900">
-                  Visit on {new Date(v.visitDate).toLocaleDateString()}
-                </h3>
-                <div className="mt-2 space-y-1 text-sm text-gray-700">
-                  <p>
-                    <span className="font-semibold">Department:</span> {v.department}
-                  </p>
-                  {v.reason && (
+            Add Visit
+          </Link>
+        </div>
+        {visits.length === 0 ? (
+          <div>No visits found.</div>
+        ) : (
+          visits.map((v) => (
+            <section
+              key={v.visitId}
+              className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-base font-semibold text-gray-900">
+                    Visit on {new Date(v.visitDate).toLocaleDateString()}
+                  </h3>
+                  <div className="mt-2 space-y-1 text-sm text-gray-700">
                     <p>
-                      <span className="font-semibold">Reason:</span> {v.reason}
+                      <span className="font-semibold">Department:</span> {v.department}
                     </p>
-                  )}
+                    {v.reason && (
+                      <p>
+                        <span className="font-semibold">Reason:</span> {v.reason}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <div className="shrink-0">
+                  <Link
+                    to={`/visits/${v.visitId}`}
+                    className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    View
+                  </Link>
                 </div>
               </div>
-              <div className="shrink-0">
-                <Link
-                  to={`/visits/${v.visitId}`}
-                  className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  View
-                </Link>
-              </div>
-            </div>
-          </section>
-        ))}
+            </section>
+          ))
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- add API helpers to create visits, diagnoses, meds, labs, and observations
- build Add Visit page with visit details, diagnoses, medications, labs, and vital inputs
- wire routes and patient detail to support adding new visits

## Testing
- `npm test` *(fails: Cannot find module './server.js' from 'src/index.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68c0ef3c1344832ebd45e4ed7f403a0a