### PR TITLE
Remove forward navigation and keep back button on patient pages

### DIFF
--- a/client/src/components/BackButton.tsx
+++ b/client/src/components/BackButton.tsx
@@ -1,22 +1,15 @@
 import { useNavigate } from 'react-router-dom';
 
-export default function NavigationButtons() {
+export default function BackButton() {
   const navigate = useNavigate();
   return (
-    <div className="mt-4 flex justify-between">
+    <div className="mt-4 flex justify-start">
       <button
         type="button"
         onClick={() => navigate(-1)}
         className="rounded bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300"
       >
         Back
-      </button>
-      <button
-        type="button"
-        onClick={() => navigate(1)}
-        className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
-      >
-        Next
       </button>
     </div>
   );

--- a/client/src/components/PatientSearch.tsx
+++ b/client/src/components/PatientSearch.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { searchPatients, type Patient } from '../api/client';
-import NavigationButtons from './NavigationButtons';
+import BackButton from './BackButton';
 
 export default function PatientSearch() {
   const [query, setQuery] = useState('');
@@ -91,7 +91,7 @@ export default function PatientSearch() {
             </tbody>
           </table>
         </div>
-        <NavigationButtons />
+        <BackButton />
       </div>
     </div>
   );

--- a/client/src/pages/AddVisit.tsx
+++ b/client/src/pages/AddVisit.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import NavigationButtons from '../components/NavigationButtons';
 import {
   createVisit,
   addDiagnosis,
@@ -267,7 +266,6 @@ export default function AddVisit() {
             {saving ? 'Saving...' : 'Save Visit'}
           </button>
         </form>
-        <NavigationButtons />
       </div>
     </div>
   );

--- a/client/src/pages/Cohort.tsx
+++ b/client/src/pages/Cohort.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { cohort, type CohortResult } from '../api/client';
 import PageLayout from '../components/PageLayout';
-import NavigationButtons from '../components/NavigationButtons';
 
 export default function Cohort() {
   const [testName, setTestName] = useState('');
@@ -113,7 +112,6 @@ export default function Cohort() {
           </tbody>
         </table>
       )}
-      <NavigationButtons />
     </PageLayout>
   );
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,11 +1,9 @@
 import PageLayout from '../components/PageLayout';
-import NavigationButtons from '../components/NavigationButtons';
 
 export default function Home() {
   return (
     <PageLayout>
       <h1>Home</h1>
-      <NavigationButtons />
     </PageLayout>
   );
 }

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthProvider';
 import LoginCard from '../components/LoginCard';
 import PageLayout from '../components/PageLayout';
-import NavigationButtons from '../components/NavigationButtons';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -47,7 +46,6 @@ export default function Login() {
         </div>
       )}
       <LoginCard onSubmit={handleSubmit} values={values} onChange={handleChange} />
-      <NavigationButtons />
     </PageLayout>
   );
 }

--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link, useLocation } from 'react-router-dom';
-import NavigationButtons from '../components/NavigationButtons';
+import BackButton from '../components/BackButton';
 import {
   getPatient,
   listPatientVisits,
@@ -215,7 +215,7 @@ export default function PatientDetail() {
         </div>
 
           {activeTab === 'summary' ? renderSummary(patient) : renderVisits()}
-        <NavigationButtons />
+        <BackButton />
       </div>
     </div>
   );

--- a/client/src/pages/VisitDetail.tsx
+++ b/client/src/pages/VisitDetail.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import NavigationButtons from '../components/NavigationButtons';
 import {
   addObservation,
   getPatient,
@@ -200,7 +199,6 @@ export default function VisitDetail() {
         <p className="mt-4 text-sm text-gray-500">
           My previous notes for this patient (before this visit)
         </p>
-        <NavigationButtons />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace generic navigation with a simple `BackButton` component
- Use `BackButton` on patient search and patient detail pages only
- Drop back/next navigation from other pages

## Testing
- `npm test` *(fails: Cannot find module './server.js' from 'src/index.ts')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f3976d2c832ea017624c0390c78d