### PR TITLE
fix: remove ts extension imports

### DIFF
--- a/src/modules/audit/index.ts
+++ b/src/modules/audit/index.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
-import { requireAuth, requireRole, type AuthRequest } from '../auth/index.ts';
+import { requireAuth, requireRole, type AuthRequest } from '../auth/index.js';
 
 const prisma = new PrismaClient();
 const router = Router();
@@ -37,5 +37,5 @@ router.get('/', requireAuth, requireRole('Admin', 'Auditor'), async (req: AuthRe
   res.json(audits);
 });
 
-export { logDataChange } from './service.ts';
+export { logDataChange } from './service.js';
 export default router;

--- a/src/modules/diagnoses/index.ts
+++ b/src/modules/diagnoses/index.ts
@@ -1,8 +1,8 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
-import { requireAuth, requireRole, type AuthRequest } from '../auth/index.ts';
-import { logDataChange } from '../audit/index.ts';
+import { requireAuth, requireRole, type AuthRequest } from '../auth/index.js';
+import { logDataChange } from '../audit/index.js';
 
 const prisma = new PrismaClient();
 const router = Router();

--- a/src/modules/doctors/index.ts
+++ b/src/modules/doctors/index.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
-import { requireAuth } from '../auth/index.ts';
+import { requireAuth } from '../auth/index.js';
 
 const prisma = new PrismaClient();
 const router = Router();

--- a/src/modules/insights/index.ts
+++ b/src/modules/insights/index.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient, Prisma } from '@prisma/client';
 import { z } from 'zod';
-import { requireAuth } from '../auth/index.ts';
+import { requireAuth } from '../auth/index.js';
 
 const prisma = new PrismaClient();
 const router = Router();

--- a/src/modules/labs/index.ts
+++ b/src/modules/labs/index.ts
@@ -1,8 +1,8 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
-import { requireAuth, requireRole, type AuthRequest } from '../auth/index.ts';
-import { logDataChange } from '../audit/index.ts';
+import { requireAuth, requireRole, type AuthRequest } from '../auth/index.js';
+import { logDataChange } from '../audit/index.js';
 
 const prisma = new PrismaClient();
 const router = Router();

--- a/src/modules/medications/index.ts
+++ b/src/modules/medications/index.ts
@@ -1,8 +1,8 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
-import { requireAuth, requireRole, type AuthRequest } from '../auth/index.ts';
-import { logDataChange } from '../audit/index.ts';
+import { requireAuth, requireRole, type AuthRequest } from '../auth/index.js';
+import { logDataChange } from '../audit/index.js';
 
 const prisma = new PrismaClient();
 const router = Router();

--- a/src/modules/observations/index.ts
+++ b/src/modules/observations/index.ts
@@ -1,8 +1,8 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient, Prisma, Observation } from '@prisma/client';
 import { z } from 'zod';
-import { requireAuth, requireRole, type AuthRequest } from '../auth/index.ts';
-import { logDataChange } from '../audit/index.ts';
+import { requireAuth, requireRole, type AuthRequest } from '../auth/index.js';
+import { logDataChange } from '../audit/index.js';
 
 const prisma = new PrismaClient();
 const router = Router();

--- a/src/modules/patients/index.ts
+++ b/src/modules/patients/index.ts
@@ -2,8 +2,8 @@ import { Router, Request, Response } from 'express';
 import { PrismaClient, Prisma } from '@prisma/client';
 import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
-import { requireAuth } from '../auth/index.ts';
-import { validate } from '../../middleware/validate.ts';
+import { requireAuth } from '../auth/index.js';
+import { validate } from '../../middleware/validate.js';
 
 const prisma = new PrismaClient();
 const router = Router();

--- a/src/modules/visits/index.ts
+++ b/src/modules/visits/index.ts
@@ -1,8 +1,8 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
-import { requireAuth, requireRole, type AuthRequest } from '../auth/index.ts';
-import { logDataChange } from '../audit/index.ts';
+import { requireAuth, requireRole, type AuthRequest } from '../auth/index.js';
+import { logDataChange } from '../audit/index.js';
 
 const prisma = new PrismaClient();
 const router = Router();

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,3 @@
 export * from './server.ts';
 import apiRouter from './server.ts';
 export default apiRouter;
-

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,15 +1,15 @@
 import { Router } from 'express';
 
-import visitsRouter from './modules/visits/index.ts';
-import patientsRouter from './modules/patients/index.ts';
-import doctorsRouter from './modules/doctors/index.ts';
-import diagnosesRouter from './modules/diagnoses/index.ts';
-import medicationsRouter from './modules/medications/index.ts';
-import labsRouter from './modules/labs/index.ts';
-import observationsRouter from './modules/observations/index.ts';
-import insightsRouter from './modules/insights/index.ts';
-import auditRouter from './modules/audit/index.ts';
-import { docsRouter } from './docs/openapi.ts';
+import visitsRouter from './modules/visits/index.js';
+import patientsRouter from './modules/patients/index.js';
+import doctorsRouter from './modules/doctors/index.js';
+import diagnosesRouter from './modules/diagnoses/index.js';
+import medicationsRouter from './modules/medications/index.js';
+import labsRouter from './modules/labs/index.js';
+import observationsRouter from './modules/observations/index.js';
+import insightsRouter from './modules/insights/index.js';
+import auditRouter from './modules/audit/index.js';
+import { docsRouter } from './docs/openapi.js';
 
 export const apiRouter = Router();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
-    "sourceMap": true,
-    "allowImportingTsExtensions": true
+    "sourceMap": true
   },
   "include": ["src", "scripts"]
 }


### PR DESCRIPTION
## Summary
- remove allowImportingTsExtensions and compile with emitted JS
- update internal imports to use `.js` extensions for NodeNext
- restore server bridge file

## Testing
- `npm run build`
- `npm test` *(fails: Must use import to load ES Module: /workspace/EMR/src/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fe4d5358832eb05e239303da025f