### PR TITLE
feat: add basic login endpoint

### DIFF
--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,4 +1,9 @@
-import { Router, type Request, type Response, type NextFunction } from 'express';
+import {
+  Router,
+  type Request,
+  type Response,
+  type NextFunction,
+} from 'express';
 
 export interface AuthUser {
   userId: string;
@@ -22,8 +27,19 @@ export function requireRole(..._roles: string[]) {
   };
 }
 
-// No authentication routes are exposed
 const router = Router();
+
+router.post('/login', (req: Request, res: Response) => {
+  const { email } = req.body || {};
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'none', typ: 'JWT' }),
+  ).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({ sub: email || 'anonymous', role: 'Doctor' }),
+  ).toString('base64url');
+  const accessToken = `${header}.${payload}.`;
+  res.json({ accessToken });
+});
 
 export default router;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import observationsRouter from './modules/observations/index.js';
 import insightsRouter from './modules/insights/index.js';
 import auditRouter from './modules/audit/index.js';
 import { docsRouter } from './docs/openapi.js';
+import authRouter from './modules/auth/index.js';
 
 export const apiRouter = Router();
 
@@ -25,6 +26,7 @@ apiRouter.use('/labs', labsRouter);
 apiRouter.use(observationsRouter);
 apiRouter.use('/insights', insightsRouter);
 apiRouter.use('/audit', auditRouter);
+apiRouter.use('/auth', authRouter);
 apiRouter.use(docsRouter);
 
 export default apiRouter;


### PR DESCRIPTION
## Summary
- implement `/api/auth/login` route returning a simple unsigned JWT so the UI can log in
- wire auth router into the API server

## Testing
- `npm test` *(fails: Cannot find module '.../jest/bin/jest.js')*
- `npm ci` *(fails: 403 Forbidden @types/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68c10edf96c0832eaa462f6aca5799db