### PR TITLE
feat: allow visit creation via api

### DIFF
--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -116,20 +116,12 @@ export default function PatientDetail() {
   function renderVisits() {
     if (visitsLoading) return <div className="mt-6">Loading visits...</div>;
     if (!visits) return null;
-    return (
-      <div className="mt-5 space-y-5">
-        <div className="flex justify-end">
-          <Link
-            to={`/patients/${id}/visits/new`}
-            className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700"
-          >
-            Add Visit
-          </Link>
-        </div>
-        {visits.length === 0 ? (
-          <div>No visits found.</div>
-        ) : (
-          visits.map((v) => (
+      return (
+        <div className="mt-5 space-y-5">
+          {visits.length === 0 ? (
+            <div>No visits found.</div>
+          ) : (
+            visits.map((v) => (
             <section
               key={v.visitId}
               className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
@@ -167,21 +159,31 @@ export default function PatientDetail() {
   }
 
   return (
-    <div className="p-4 md:p-6">
-      <div className="mx-auto max-w-4xl rounded-2xl bg-white shadow-xl p-5 md:p-7">
-        <div>
-          <h1 className="text-2xl font-semibold text-gray-900">
-            {patient.name}
-          </h1>
-          <p className="mt-1 text-sm text-gray-700">
-            <span className="font-semibold">DOB:</span>{' '}
-            {new Date(patient.dob).toLocaleDateString()}
-          </p>
-          <p className="mt-1 text-sm text-gray-700">
-            <span className="font-semibold">Insurance:</span>{' '}
-            {patient.insurance || ''}
-          </p>
-        </div>
+      <div className="p-4 md:p-6">
+        <div className="mx-auto max-w-4xl rounded-2xl bg-white shadow-xl p-5 md:p-7">
+          <div className="flex items-start justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900">
+                {patient.name}
+              </h1>
+              <p className="mt-1 text-sm text-gray-700">
+                <span className="font-semibold">DOB:</span>{' '}
+                {new Date(patient.dob).toLocaleDateString()}
+              </p>
+              <p className="mt-1 text-sm text-gray-700">
+                <span className="font-semibold">Insurance:</span>{' '}
+                {patient.insurance || ''}
+              </p>
+            </div>
+            <div className="mt-4 shrink-0">
+              <Link
+                to={`/patients/${id}/visits/new`}
+                className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700"
+              >
+                Add Visit
+              </Link>
+            </div>
+          </div>
 
         <div className="mt-4 border-b border-gray-200">
           <nav role="tablist" className="flex gap-6">

--- a/src/docs/openapi.ts
+++ b/src/docs/openapi.ts
@@ -176,7 +176,32 @@ addPath('/auth/password/reset', 'post', {
 addPath('/visits', 'post', {
   summary: 'Create visit',
   security: [{ bearerAuth: [] }],
-  responses: { '201': { description: 'Created', content: { 'application/json': { schema: { $ref: '#/components/schemas/Visit' } } } } }
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          required: ['patientId', 'visitDate', 'doctorId', 'department'],
+          properties: {
+            patientId: { type: 'string', format: 'uuid' },
+            visitDate: { type: 'string', format: 'date' },
+            doctorId: { type: 'string', format: 'uuid' },
+            department: { type: 'string' },
+            reason: { type: 'string', nullable: true },
+          },
+        },
+      },
+    },
+  },
+  responses: {
+    '201': {
+      description: 'Created',
+      content: {
+        'application/json': { schema: { $ref: '#/components/schemas/Visit' } },
+      },
+    },
+  },
 });
 
 addPath('/patients/{id}/visits', 'get', {


### PR DESCRIPTION
## Summary
- document visit creation endpoint in OpenAPI spec
- move "Add Visit" button beside patient header and right-align it

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcors)*

------
https://chatgpt.com/codex/tasks/task_e_68c11eefa0d4832e9e9f7faae46e5aaf