### PR TITLE
Add global logout button

### DIFF
--- a/client/src/components/LogoutButton.tsx
+++ b/client/src/components/LogoutButton.tsx
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthProvider';
+
+export default function LogoutButton() {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
+  function handleClick() {
+    logout();
+    navigate('/login');
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="rounded bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300"
+    >
+      Logout
+    </button>
+  );
+}

--- a/client/src/components/RouteGuard.tsx
+++ b/client/src/components/RouteGuard.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthProvider';
+import LogoutButton from './LogoutButton';
 
 interface Props {
   children: ReactNode;
@@ -12,5 +13,12 @@ export default function RouteGuard({ children }: Props) {
   if (!accessToken) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
-  return <>{children}</>;
+  return (
+    <>
+      <div className="fixed top-4 right-4">
+        <LogoutButton />
+      </div>
+      {children}
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- introduce a LogoutButton component to clear auth state and redirect to login
- render the LogoutButton from RouteGuard so it appears on all authenticated pages

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c13b2c2870832e9310063ccaeac210