### PR TITLE
feat: add settings page and app branding

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import PatientDetail from './pages/PatientDetail';
 import VisitDetail from './pages/VisitDetail';
 import AddVisit from './pages/AddVisit';
 import Cohort from './pages/Cohort';
+import Settings from './pages/Settings';
 import './styles/App.css';
 
 function App() {
@@ -50,6 +51,14 @@ function App() {
         element={
           <RouteGuard>
             <Cohort />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/settings"
+        element={
+          <RouteGuard>
+            <Settings />
           </RouteGuard>
         }
       />

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom';
+import LogoutButton from './LogoutButton';
+import { useSettings } from '../context/SettingsProvider';
+import { useAuth } from '../context/AuthProvider';
+
+export default function Header() {
+  const { appName, logo } = useSettings();
+  const { accessToken } = useAuth();
+  return (
+    <header className="flex items-center justify-between bg-blue-600 px-4 py-2 text-white">
+      <div className="flex items-center">
+        {logo && (
+          <img src={logo} alt="logo" className="mr-2 h-8 w-8 rounded" />
+        )}
+        <span className="text-lg font-semibold">{appName}</span>
+      </div>
+      <div className="flex items-center space-x-4">
+        <Link to="/settings" className="text-sm hover:underline">
+          Settings
+        </Link>
+        {accessToken && (
+          <LogoutButton className="rounded bg-white/20 px-3 py-1 text-sm text-white hover:bg-white/30" />
+        )}
+      </div>
+    </header>
+  );
+}

--- a/client/src/components/LoginCard.tsx
+++ b/client/src/components/LoginCard.tsx
@@ -4,28 +4,40 @@ interface LoginCardProps {
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   values: { username: string; password: string };
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  appName: string;
+  logo?: string | null;
 }
 
-export default function LoginCard({ onSubmit, values, onChange }: LoginCardProps) {
+export default function LoginCard({
+  onSubmit,
+  values,
+  onChange,
+  appName,
+  logo,
+}: LoginCardProps) {
   return (
     <div className="rounded-2xl bg-white p-8 shadow">
       <div className="mb-6 flex flex-col items-center">
-        <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-600">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="h-6 w-6 text-white"
-            aria-hidden="true"
-          >
-            <path d="M12 6v12M6 12h12" />
-          </svg>
-        </div>
-        <h1 className="text-2xl font-bold text-gray-900">EMR System</h1>
+        {logo ? (
+          <img src={logo} alt="logo" className="mb-4 h-12 w-12 rounded" />
+        ) : (
+          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-600">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-6 w-6 text-white"
+              aria-hidden="true"
+            >
+              <path d="M12 6v12M6 12h12" />
+            </svg>
+          </div>
+        )}
+        <h1 className="text-2xl font-bold text-gray-900">{appName}</h1>
         <p className="mt-2 text-sm text-gray-600">Sign in to your account</p>
       </div>
 

--- a/client/src/components/LogoutButton.tsx
+++ b/client/src/components/LogoutButton.tsx
@@ -1,7 +1,13 @@
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthProvider';
 
-export default function LogoutButton() {
+interface Props {
+  className?: string;
+}
+
+export default function LogoutButton({
+  className = 'rounded bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300',
+}: Props) {
   const { logout } = useAuth();
   const navigate = useNavigate();
 
@@ -11,11 +17,7 @@ export default function LogoutButton() {
   }
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      className="rounded bg-gray-200 px-4 py-2 text-gray-700 hover:bg-gray-300"
-    >
+    <button type="button" onClick={handleClick} className={className}>
       Logout
     </button>
   );

--- a/client/src/components/RouteGuard.tsx
+++ b/client/src/components/RouteGuard.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthProvider';
-import LogoutButton from './LogoutButton';
+import Header from './Header';
 
 interface Props {
   children: ReactNode;
@@ -15,9 +15,7 @@ export default function RouteGuard({ children }: Props) {
   }
   return (
     <>
-      <div className="fixed top-4 right-4">
-        <LogoutButton />
-      </div>
+      <Header />
       {children}
     </>
   );

--- a/client/src/context/SettingsProvider.tsx
+++ b/client/src/context/SettingsProvider.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+interface UserAccount {
+  email: string;
+  password: string;
+}
+
+interface SettingsContextType {
+  appName: string;
+  logo: string | null;
+  users: UserAccount[];
+  updateSettings: (data: { appName?: string; logo?: string | null }) => void;
+  addUser: (user: UserAccount) => void;
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [appName, setAppName] = useState<string>('EMR System');
+  const [logo, setLogo] = useState<string | null>(null);
+  const [users, setUsers] = useState<UserAccount[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('appSettings');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (parsed.appName) setAppName(parsed.appName);
+        if (parsed.logo) setLogo(parsed.logo);
+        if (Array.isArray(parsed.users)) setUsers(parsed.users);
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('appSettings', JSON.stringify({ appName, logo, users }));
+  }, [appName, logo, users]);
+
+  const updateSettings = (data: { appName?: string; logo?: string | null }) => {
+    if (data.appName !== undefined) setAppName(data.appName);
+    if (data.logo !== undefined) setLogo(data.logo);
+  };
+
+  const addUser = (user: UserAccount) => {
+    setUsers((prev) => [...prev, user]);
+  };
+
+  return (
+    <SettingsContext.Provider value={{ appName, logo, users, updateSettings, addUser }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error('useSettings must be used within SettingsProvider');
+  return ctx;
+};
+

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,12 +4,15 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './styles/index.css';
 import { AuthProvider } from './context/AuthProvider';
+import { SettingsProvider } from './context/SettingsProvider';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <AuthProvider>
-        <App />
+        <SettingsProvider>
+          <App />
+        </SettingsProvider>
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthProvider';
 import LoginCard from '../components/LoginCard';
 import PageLayout from '../components/PageLayout';
+import { useSettings } from '../context/SettingsProvider';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -11,6 +12,7 @@ export default function Login() {
   const [success, setSuccess] = useState<string | null>(null);
   const { login } = useAuth();
   const navigate = useNavigate();
+  const { appName, logo } = useSettings();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -45,7 +47,13 @@ export default function Login() {
           {success}
         </div>
       )}
-      <LoginCard onSubmit={handleSubmit} values={values} onChange={handleChange} />
+      <LoginCard
+        onSubmit={handleSubmit}
+        values={values}
+        onChange={handleChange}
+        appName={appName}
+        logo={logo}
+      />
     </PageLayout>
   );
 }

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { useSettings } from '../context/SettingsProvider';
+
+export default function Settings() {
+  const { appName, logo, users, updateSettings, addUser } = useSettings();
+  const [name, setName] = useState(appName);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      updateSettings({ logo: reader.result as string });
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    updateSettings({ appName: name });
+  }
+
+  function handleAddUser(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email) return;
+    addUser({ email, password });
+    setEmail('');
+    setPassword('');
+  }
+
+  return (
+    <div className="p-4 md:p-6">
+      <div className="mx-auto max-w-xl space-y-6">
+        <form onSubmit={handleSave} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Application Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Logo
+            </label>
+            <input type="file" accept="image/*" onChange={handleLogoChange} />
+            {logo && <img src={logo} alt="logo" className="mt-2 h-16" />}
+          </div>
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+          >
+            Save Settings
+          </button>
+        </form>
+
+        <div>
+          <h2 className="mb-2 text-lg font-semibold">Create User</h2>
+          <form onSubmit={handleAddUser} className="space-y-2">
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+            <button
+              type="submit"
+              className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+            >
+              Add User
+            </button>
+          </form>
+          {users.length > 0 && (
+            <ul className="mt-4 list-disc pl-5">
+              {users.map((u, i) => (
+                <li key={i} className="text-sm text-gray-700">
+                  {u.email}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add context and settings page to manage app name, logo, and user accounts
- display logo and app name in a shared header and login screen

## Testing
- `npm test` (fails: Cannot find module 'jest/bin/jest.js')
- `npm install` (fails: 403 Forbidden on registry)
- `npm run lint` (fails: ESLint config missing)


------
https://chatgpt.com/codex/tasks/task_e_68c13c7c0470832e9b392379879ecd91