### PR TITLE
fix: preserve login logo aspect ratio

### DIFF
--- a/client/src/components/LoginCard.tsx
+++ b/client/src/components/LoginCard.tsx
@@ -19,7 +19,11 @@ export default function LoginCard({
     <div className="rounded-2xl bg-white p-8 shadow">
       <div className="mb-6 flex flex-col items-center">
         {logo ? (
-          <img src={logo} alt="logo" className="mb-4 h-12 w-12 rounded" />
+          <img
+            src={logo}
+            alt="logo"
+            className="mb-4 h-12 w-auto rounded object-contain"
+          />
         ) : (
           <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-600">
             <svg


### PR DESCRIPTION
## Summary
- keep login logo's width flexible so it isn't squashed

## Testing
- `npm test` *(fails: Cannot find module '/workspace/EMR/node_modules/jest/bin/jest.js')*
- `npm install` *(fails: 403 Forbidden for @types/cors)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68c13e893848832e977773bbcee7f99f