### PR TITLE
Align header layout and prevent logo distortion

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -7,12 +7,14 @@ export default function Header() {
   const { appName, logo } = useSettings();
   const { accessToken } = useAuth();
   return (
-    <header className="flex items-center justify-center bg-gray-600 px-4 py-4 text-white">
+    <header className="flex items-center justify-between bg-gray-600 px-4 py-4 text-white">
       <div className="flex items-center space-x-4">
         {logo && (
-          <img src={logo} alt="logo" className="h-16 w-16 rounded" />
+          <img src={logo} alt="logo" className="h-16 w-auto rounded" />
         )}
         <span className="text-xl font-semibold">{appName}</span>
+      </div>
+      <div className="flex items-center space-x-4">
         <Link to="/settings" className="text-sm hover:underline">
           Settings
         </Link>


### PR DESCRIPTION
## Summary
- Left align logo and app name while right aligning settings and logout
- Preserve logo aspect ratio to avoid distortion

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcors)*

------
https://chatgpt.com/codex/tasks/task_e_68c140dc781c832e964ab2d32c2d0b8d