### PR TITLE
Center header logo and app name

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -7,14 +7,14 @@ export default function Header() {
   const { appName, logo } = useSettings();
   const { accessToken } = useAuth();
   return (
-    <header className="flex items-center justify-between bg-gray-600 px-4 py-4 text-white">
+    <header className="relative flex items-center justify-center bg-gray-600 px-4 py-4 text-white">
       <div className="flex items-center space-x-4">
         {logo && (
           <img src={logo} alt="logo" className="h-16 w-auto rounded" />
         )}
         <span className="text-xl font-semibold">{appName}</span>
       </div>
-      <div className="flex items-center space-x-4">
+      <div className="absolute right-4 flex items-center space-x-4">
         <Link to="/settings" className="text-sm hover:underline">
           Settings
         </Link>


### PR DESCRIPTION
## Summary
- center logo and application name in header
- keep settings and logout controls aligned right

## Testing
- `npm test` *(fails: Cannot find module '/workspace/EMR/node_modules/jest/bin/jest.js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcors)*

------
https://chatgpt.com/codex/tasks/task_e_68c142b2be6c832eba742eded1e46492