### PR TITLE
Redirect to home after login

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -21,7 +21,7 @@ export default function Login() {
     try {
       await login(email, password);
       setSuccess('Login successful');
-      navigate('/patients');
+      navigate('/');
     } catch (err: any) {
       setError(err.message);
     }


### PR DESCRIPTION
## Summary
- Redirect users to home page after successful login instead of patient search

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: Cannot find module 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_68c14824363c832e8d230e3a005db437