### PR TITLE
feat: allow adding doctors

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -117,6 +117,19 @@ export async function listDoctors(): Promise<Doctor[]> {
   return fetchJSON('/doctors');
 }
 
+export interface CreateDoctorPayload {
+  name: string;
+  department: string;
+}
+
+export async function createDoctor(payload: CreateDoctorPayload): Promise<Doctor> {
+  return fetchJSON('/doctors', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
 export async function getPatient(
   id: string,
   params?: { include?: 'summary' },

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -36,10 +36,10 @@ export default function Settings() {
     setPassword('');
   }
 
-  function handleAddDoctor(e: React.FormEvent) {
+  async function handleAddDoctor(e: React.FormEvent) {
     e.preventDefault();
     if (!docName || !dept) return;
-    addDoctor({ name: docName, department: dept });
+    await addDoctor({ name: docName, department: dept });
     setDocName('');
     setDept('');
   }

--- a/src/docs/openapi.ts
+++ b/src/docs/openapi.ts
@@ -283,6 +283,32 @@ addPath('/doctors', 'get', {
   responses: { '200': { description: 'Doctors', content: { 'application/json': { schema: { type: 'array', items: { $ref: '#/components/schemas/Doctor' } } } } } }
 });
 
+addPath('/doctors', 'post', {
+  summary: 'Create doctor',
+  security: [{ bearerAuth: [] }],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          required: ['name', 'department'],
+          properties: {
+            name: { type: 'string' },
+            department: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+  responses: {
+    '201': {
+      description: 'Doctor',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/Doctor' } } },
+    },
+  },
+});
+
 addPath('/visits/{id}/diagnoses', 'post', {
   summary: 'Add diagnosis',
   security: [{ bearerAuth: [] }],

--- a/src/modules/doctors/index.ts
+++ b/src/modules/doctors/index.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
-import { requireAuth } from '../auth/index.js';
+import { requireAuth, requireRole, type AuthRequest } from '../auth/index.js';
 
 const prisma = new PrismaClient();
 const router = Router();
@@ -9,6 +9,11 @@ const router = Router();
 const querySchema = z.object({
   department: z.string().optional(),
   q: z.string().optional(),
+});
+
+const createSchema = z.object({
+  name: z.string().min(1),
+  department: z.string().min(1),
 });
 
 router.get('/', requireAuth, async (req: Request, res: Response) => {
@@ -26,6 +31,15 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
   }
   const doctors = await prisma.doctor.findMany({ where, orderBy: { name: 'asc' } });
   res.json(doctors);
+});
+
+router.post('/', requireAuth, requireRole('Admin'), async (req: AuthRequest, res: Response) => {
+  const parsed = createSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const doctor = await prisma.doctor.create({ data: parsed.data });
+  res.status(201).json(doctor);
 });
 
 export default router;

--- a/tests/doctors.test.ts
+++ b/tests/doctors.test.ts
@@ -1,0 +1,31 @@
+import request from 'supertest';
+import { app } from '../src/index';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+beforeAll(async () => {
+  await prisma.doctor.deleteMany({});
+});
+
+afterAll(async () => {
+  await prisma.doctor.deleteMany({});
+  await prisma.$disconnect();
+});
+
+describe('Doctor management', () => {
+  it('creates and lists doctors', async () => {
+    const createRes = await request(app)
+      .post('/api/doctors')
+      .send({ name: 'Dr. Test', department: 'Testing' });
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.doctorId;
+    expect(id).toBeDefined();
+
+    const listRes = await request(app).get('/api/doctors');
+    expect(listRes.status).toBe(200);
+    const ids = listRes.body.map((d: any) => d.doctorId);
+    expect(ids).toContain(id);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add POST /doctors API and document in OpenAPI spec
- allow frontend to create doctors via settings and fetch them from backend
- test doctor creation and listing

## Testing
- `npm test` *(fails: Cannot find module '/workspace/EMR/node_modules/jest/bin/jest.js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcors)*

------
https://chatgpt.com/codex/tasks/task_e_68c14b193068832eadb9d5e1a9b73a86