### PR TITLE
feat: navigate home on logo click

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -10,7 +10,9 @@ export default function Header() {
     <header className="relative flex items-center justify-center bg-gray-600 px-4 py-4 text-white">
       <div className="flex items-center space-x-4">
         {logo && (
-          <img src={logo} alt="logo" className="h-16 w-auto rounded" />
+          <Link to="/">
+            <img src={logo} alt="logo" className="h-16 w-auto rounded" />
+          </Link>
         )}
         <span className="text-xl font-semibold">{appName}</span>
       </div>


### PR DESCRIPTION
## Summary
- make header logo link to home for quick navigation

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c14cc688c4832ead7e3f7ac29373e9