### PR TITLE
Return full visit details from CreateVisit API

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -156,7 +156,7 @@ export interface CreateVisitPayload {
   reason?: string;
 }
 
-export async function createVisit(payload: CreateVisitPayload): Promise<Visit> {
+export async function createVisit(payload: CreateVisitPayload): Promise<VisitDetail> {
   return fetchJSON('/visits', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/src/docs/openapi.ts
+++ b/src/docs/openapi.ts
@@ -40,6 +40,22 @@ const openapi: any = {
           doctor: { $ref: '#/components/schemas/Doctor' }
         }
       },
+      VisitDetail: {
+        type: 'object',
+        properties: {
+          visitId: { type: 'string', format: 'uuid' },
+          patientId: { type: 'string', format: 'uuid' },
+          doctorId: { type: 'string', format: 'uuid' },
+          visitDate: { type: 'string', format: 'date' },
+          department: { type: 'string' },
+          reason: { type: 'string', nullable: true },
+          doctor: { $ref: '#/components/schemas/Doctor' },
+          diagnoses: { type: 'array', items: { $ref: '#/components/schemas/Diagnosis' } },
+          medications: { type: 'array', items: { $ref: '#/components/schemas/Medication' } },
+          labResults: { type: 'array', items: { $ref: '#/components/schemas/LabResult' } },
+          observations: { type: 'array', items: { $ref: '#/components/schemas/Observation' } },
+        }
+      },
       Diagnosis: {
         type: 'object',
         properties: {
@@ -192,7 +208,7 @@ addPath('/visits', 'post', {
     '201': {
       description: 'Created',
       content: {
-        'application/json': { schema: { $ref: '#/components/schemas/Visit' } },
+        'application/json': { schema: { $ref: '#/components/schemas/VisitDetail' } },
       },
     },
   },
@@ -209,7 +225,13 @@ addPath('/visits/{id}', 'get', {
   summary: 'Get visit detail',
   security: [],
   parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string', format: 'uuid' } }],
-  responses: { '200': { description: 'Visit', content: { 'application/json': { schema: { $ref: '#/components/schemas/Visit' } } } }, '404': { description: 'Not found' } }
+  responses: {
+    '200': {
+      description: 'Visit',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/VisitDetail' } } },
+    },
+    '404': { description: 'Not found' },
+  },
 });
 
 addPath('/patients', 'post', {

--- a/src/modules/visits/index.ts
+++ b/src/modules/visits/index.ts
@@ -22,7 +22,13 @@ router.post('/visits', requireAuth, requireRole('Doctor', 'Admin'), async (req: 
   }
   const visit = await prisma.visit.create({
     data: parsed.data,
-    include: { doctor: { select: { doctorId: true, name: true, department: true } } },
+    include: {
+      doctor: { select: { doctorId: true, name: true, department: true } },
+      diagnoses: { orderBy: { createdAt: 'desc' } },
+      medications: { orderBy: { createdAt: 'desc' } },
+      labResults: { orderBy: { createdAt: 'desc' } },
+      observations: { orderBy: { createdAt: 'desc' } },
+    },
   });
   await logDataChange(req.user!.userId, 'visit', visit.visitId, undefined, visit);
   res.status(201).json(visit);

--- a/tests/visits.test.ts
+++ b/tests/visits.test.ts
@@ -43,6 +43,10 @@ describe('Visit lifecycle', () => {
     expect(createRes.status).toBe(201);
     visitId = createRes.body.visitId;
     expect(createRes.body.doctor.doctorId).toBe(doctorId);
+    expect(createRes.body.diagnoses).toEqual([]);
+    expect(createRes.body.medications).toEqual([]);
+    expect(createRes.body.labResults).toEqual([]);
+    expect(createRes.body.observations).toEqual([]);
 
     await prisma.diagnosis.create({ data: { visitId, diagnosis: 'Flu' } });
     await prisma.medication.create({ data: { visitId, drugName: 'Tamiflu' } });


### PR DESCRIPTION
## Summary
- Include diagnoses, medications, lab results, and observations in CreateVisit response
- Document new VisitDetail schema and responses in OpenAPI spec
- Adjust client and tests for VisitDetail responses

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcors)*

------
https://chatgpt.com/codex/tasks/task_e_68c15ca2a358832e8346ee877b3e2560