### PR TITLE
feat: add chat widget toggle

### DIFF
--- a/client/src/components/RouteGuard.tsx
+++ b/client/src/components/RouteGuard.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthProvider';
 import Header from './Header';
+import { useSettings } from '../context/SettingsProvider';
 
 interface Props {
   children: ReactNode;
@@ -9,6 +10,7 @@ interface Props {
 
 export default function RouteGuard({ children }: Props) {
   const { accessToken } = useAuth();
+  const { widgetEnabled } = useSettings();
   const location = useLocation();
   if (!accessToken) {
     return <Navigate to="/login" state={{ from: location }} replace />;
@@ -17,6 +19,14 @@ export default function RouteGuard({ children }: Props) {
     <>
       <Header />
       {children}
+      {widgetEnabled && (
+        <iframe
+          src="https://demo.atenxion.ai/chat-widget?agentchainId=68c11a6aac23300903b7d455"
+          style={{ bottom: 0, right: 0, width: '90%', height: '90%', position: 'fixed' }}
+          frameBorder="0"
+          allow="midi 'src'; geolocation 'src'; microphone 'src'; camera 'src'; display-capture 'src'; encrypted-media 'src';"
+        ></iframe>
+      )}
     </>
   );
 }

--- a/client/src/context/SettingsProvider.tsx
+++ b/client/src/context/SettingsProvider.tsx
@@ -14,6 +14,8 @@ interface SettingsContextType {
   updateSettings: (data: { appName?: string; logo?: string | null }) => void;
   addUser: (user: UserAccount) => void;
   addDoctor: (doctor: { name: string; department: string }) => Promise<void>;
+  widgetEnabled: boolean;
+  setWidgetEnabled: (enabled: boolean) => void;
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
@@ -23,6 +25,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [logo, setLogo] = useState<string | null>(null);
   const [users, setUsers] = useState<UserAccount[]>([]);
   const [doctors, setDoctors] = useState<Doctor[]>([]);
+  const [widgetEnabled, setWidgetEnabled] = useState<boolean>(false);
 
   useEffect(() => {
     const stored = localStorage.getItem('appSettings');
@@ -32,6 +35,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         if (parsed.appName) setAppName(parsed.appName);
         if (parsed.logo) setLogo(parsed.logo);
         if (Array.isArray(parsed.users)) setUsers(parsed.users);
+        if (typeof parsed.widgetEnabled === 'boolean') setWidgetEnabled(parsed.widgetEnabled);
       } catch {
         /* ignore */
       }
@@ -43,8 +47,11 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   }, []);
 
   useEffect(() => {
-    localStorage.setItem('appSettings', JSON.stringify({ appName, logo, users }));
-  }, [appName, logo, users]);
+    localStorage.setItem(
+      'appSettings',
+      JSON.stringify({ appName, logo, users, widgetEnabled }),
+    );
+  }, [appName, logo, users, widgetEnabled]);
 
   const updateSettings = (data: { appName?: string; logo?: string | null }) => {
     if (data.appName !== undefined) setAppName(data.appName);
@@ -62,7 +69,17 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
   return (
     <SettingsContext.Provider
-      value={{ appName, logo, users, doctors, updateSettings, addUser, addDoctor }}
+      value={{
+        appName,
+        logo,
+        users,
+        doctors,
+        updateSettings,
+        addUser,
+        addDoctor,
+        widgetEnabled,
+        setWidgetEnabled,
+      }}
     >
       {children}
     </SettingsContext.Provider>

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -4,8 +4,17 @@ import { useSettings } from '../context/SettingsProvider';
 type TabKey = 'general' | 'doctor';
 
 export default function Settings() {
-  const { appName, logo, users, doctors, updateSettings, addUser, addDoctor } =
-    useSettings();
+  const {
+    appName,
+    logo,
+    users,
+    doctors,
+    updateSettings,
+    addUser,
+    addDoctor,
+    widgetEnabled,
+    setWidgetEnabled,
+  } = useSettings();
   const [name, setName] = useState(appName);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -90,6 +99,17 @@ export default function Settings() {
                 </label>
                 <input type="file" accept="image/*" onChange={handleLogoChange} />
                 {logo && <img src={logo} alt="logo" className="mt-2 h-16" />}
+              </div>
+              <div>
+                <label className="flex items-center space-x-2 text-sm font-medium text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={widgetEnabled}
+                    onChange={(e) => setWidgetEnabled(e.target.checked)}
+                    className="rounded border-gray-300"
+                  />
+                  <span>Widget On/Off</span>
+                </label>
               </div>
               <button
                 type="submit"


### PR DESCRIPTION
## Summary
- add Atenxion chat widget to authenticated pages
- allow enabling/disabling widget via settings toggle

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c254bd3534832eab70b98440543a25