### PR TITLE
Allow external widget iframe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,17 @@ if (
 
 export const app = express();
 app.disable('x-powered-by');
-app.use(helmet());
+app.use(
+  helmet({
+    frameguard: false,
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        frameSrc: ["'self'", 'https://demo.atenxion.ai'],
+      },
+    },
+  })
+);
 
 if (process.env.NODE_ENV !== 'production') {
   app.use(cors({ origin: 'http://localhost:5173', credentials: true }));


### PR DESCRIPTION
## Summary
- configure Helmet to permit `https://demo.atenxion.ai` in iframes
- disable frameguard so widget can be embedded on other sites

## Testing
- `npm test` *(fails: Cannot find module '/workspace/EMR/node_modules/jest/bin/jest.js')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68c259294160832e89036823f721531e