### PR TITLE
fix: update chat widget id

### DIFF
--- a/client/src/components/RouteGuard.tsx
+++ b/client/src/components/RouteGuard.tsx
@@ -21,7 +21,7 @@ export default function RouteGuard({ children }: Props) {
       {children}
       {widgetEnabled && (
         <iframe
-          src="https://demo.atenxion.ai/chat-widget?agentchainId=68c11a6aac23300903b7d455"
+          src="https://demo.atenxion.ai/chat-widget?chatbotId=68c11a6aac23300903b7d455"
           style={{ bottom: 0, right: 0, width: '90%', height: '90%', position: 'fixed' }}
           frameBorder="0"
           allow="midi 'src'; geolocation 'src'; microphone 'src'; camera 'src'; display-capture 'src'; encrypted-media 'src';"


### PR DESCRIPTION
## Summary
- use `chatbotId` parameter for chat widget iframe

## Testing
- `npm test` *(fails: Cannot find module '/workspace/EMR/node_modules/jest/bin/jest.js')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68c291534d88832e905fe358ffe04d92