### PR TITLE
Sync browser tab title with configured app name

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Application Name</title>
+    <title>EMR System</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/context/SettingsProvider.tsx
+++ b/client/src/context/SettingsProvider.tsx
@@ -53,6 +53,12 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     );
   }, [appName, logo, users, widgetEnabled]);
 
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.title = appName || 'EMR System';
+    }
+  }, [appName]);
+
   const updateSettings = (data: { appName?: string; logo?: string | null }) => {
     if (data.appName !== undefined) setAppName(data.appName);
     if (data.logo !== undefined) setLogo(data.logo);


### PR DESCRIPTION
## Summary
- update the settings provider to keep the document title in sync with the configured application name
- align the default HTML title with the provider's default name so the tab is correct before React mounts

## Testing
- npm run build (client)


------
https://chatgpt.com/codex/tasks/task_e_68c8eb28c980832e97434d3a74c0a3ec