### PR TITLE
Align header branding to left

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -7,7 +7,7 @@ export default function Header() {
   const { appName, logo } = useSettings();
   const { accessToken } = useAuth();
   return (
-    <header className="relative flex items-center justify-center bg-gray-600 px-4 py-4 text-white">
+    <header className="flex items-center justify-between bg-gray-600 px-4 py-4 text-white">
       <div className="flex items-center space-x-4">
         {logo && (
           <Link to="/">
@@ -16,7 +16,7 @@ export default function Header() {
         )}
         <span className="text-xl font-semibold">{appName}</span>
       </div>
-      <div className="absolute right-4 flex items-center space-x-4">
+      <div className="flex items-center space-x-4">
         <Link to="/settings" className="text-sm hover:underline">
           Settings
         </Link>


### PR DESCRIPTION
## Summary
- left-align the header branding by using a standard flex layout instead of centered positioning
- keep the settings and logout controls aligned on the right within the header bar

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcors)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0ab1d528832e9f54e9453de0f08c