### PR TITLE
Refine patient and visit detail experiences

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -5,6 +5,8 @@ export interface Patient {
   name: string;
   dob: string;
   insurance: string | null;
+  gender?: string | null;
+  contact?: string | null;
 }
 
 export interface Doctor {

--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -1,6 +1,8 @@
+
 import { useEffect, useState } from 'react';
-import { useParams, Link, useLocation } from 'react-router-dom';
-import BackButton from '../components/BackButton';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+import { PatientsIcon, SearchIcon } from '../components/icons';
 import {
   getPatient,
   listPatientVisits,
@@ -8,224 +10,534 @@ import {
   type Visit,
 } from '../api/client';
 
+function formatDate(value: string | Date | null | undefined) {
+  if (!value) return '—';
+  const date = typeof value === 'string' ? new Date(value) : value;
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleDateString();
+}
+
+function formatDateTime(value: string | Date | null | undefined) {
+  if (!value) return '—';
+  const date = typeof value === 'string' ? new Date(value) : value;
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString();
+}
+
+function calculateAge(dob: string) {
+  const birth = new Date(dob);
+  if (Number.isNaN(birth.getTime())) return null;
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+function formatGender(gender?: string | null) {
+  if (!gender) return 'Not recorded';
+  const normalized = gender.toLowerCase();
+  if (normalized === 'm') return 'Male';
+  if (normalized === 'f') return 'Female';
+  return gender;
+}
+
 export default function PatientDetail() {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
+  const navigate = useNavigate();
   const initialTab =
     new URLSearchParams(location.search).get('tab') === 'visits'
       ? 'visits'
       : 'summary';
-  const [patient, setPatient] = useState<PatientSummary | null>(null);
+
   const [activeTab, setActiveTab] = useState<'summary' | 'visits'>(initialTab);
+  const [patient, setPatient] = useState<PatientSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [visits, setVisits] = useState<Visit[] | null>(null);
   const [visitsLoading, setVisitsLoading] = useState(false);
+  const [visitsError, setVisitsError] = useState<string | null>(null);
 
   useEffect(() => {
-    async function load() {
-      if (!id) return;
+    setActiveTab(initialTab);
+  }, [initialTab]);
+
+  useEffect(() => {
+    const patientId = id;
+    if (!patientId) {
+      setError('Patient identifier is missing.');
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setPatient(null);
+
+    async function load(targetId: string) {
       try {
-        const data = await getPatient(id, { include: 'summary' });
-        setPatient(data as PatientSummary);
+        const data = await getPatient(targetId, { include: 'summary' });
+        if (!cancelled) {
+          setPatient(data as PatientSummary);
+        }
       } catch (err) {
         console.error(err);
+        if (!cancelled) {
+          setError('Unable to load patient details right now.');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     }
-    load();
+
+    load(patientId);
+
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
   useEffect(() => {
-    async function loadVisits() {
-      if (activeTab !== 'visits' || !id || visits) return;
-      setVisitsLoading(true);
+    setVisits(null);
+    setVisitsError(null);
+  }, [id]);
+
+  useEffect(() => {
+    const patientId = id;
+    if (activeTab !== 'visits' || !patientId || visits !== null) {
+      return;
+    }
+
+    let cancelled = false;
+    setVisitsLoading(true);
+    setVisitsError(null);
+
+    async function loadVisits(targetId: string) {
       try {
-        const data = await listPatientVisits(id);
-        setVisits(data);
+        const data = await listPatientVisits(targetId);
+        if (!cancelled) {
+          setVisits(data);
+        }
       } catch (err) {
         console.error(err);
+        if (!cancelled) {
+          setVisitsError('Unable to load the full visit history.');
+        }
       } finally {
-        setVisitsLoading(false);
+        if (!cancelled) {
+          setVisitsLoading(false);
+        }
       }
     }
-    loadVisits();
+
+    loadVisits(patientId);
+
+    return () => {
+      cancelled = true;
+    };
   }, [activeTab, id, visits]);
 
-  if (!patient)
-    return (
-      <div className="p-4 md:p-6">
-        <div className="mx-auto max-w-4xl rounded-2xl bg-white shadow-xl p-5 md:p-7">
-          <div>Loading...</div>
-        </div>
-      </div>
+  function handleTabChange(tab: 'summary' | 'visits') {
+    setActiveTab(tab);
+    const params = new URLSearchParams(location.search);
+    if (tab === 'summary') {
+      params.delete('tab');
+    } else {
+      params.set('tab', 'visits');
+    }
+    navigate(
+      {
+        pathname: location.pathname,
+        search: params.toString() ? `?${params.toString()}` : '',
+      },
+      { replace: true },
     );
+  }
+
+  const headerActions = (
+    <div className="flex flex-col gap-2 md:flex-row md:items-center">
+      <Link
+        to="/patients"
+        className="inline-flex items-center justify-center rounded-full border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+      >
+        Patient Directory
+      </Link>
+      {id && (
+        <Link
+          to={`/patients/${id}/visits/new`}
+          className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+        >
+          Add Visit
+        </Link>
+      )}
+    </div>
+  );
+
+  const subtitle = patient
+    ? `Patient ID: ${patient.patientId}`
+    : loading
+      ? 'Loading patient details...'
+      : error ?? 'Patient details unavailable.';
 
   function renderSummary(p: PatientSummary) {
     if (!p.visits || p.visits.length === 0) {
-      return <div className="mt-6">No visit history.</div>;
+      return (
+        <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center">
+          <PatientsIcon className="h-12 w-12 text-gray-300" />
+          <p className="text-sm font-medium text-gray-600">No visits recorded yet.</p>
+          {id && (
+            <Link
+              to={`/patients/${id}/visits/new`}
+              className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+            >
+              Add the first visit
+            </Link>
+          )}
+        </div>
+      );
     }
+
     return (
-      <div className="mt-5 space-y-5">
-        {p.visits.map((visit) => (
-          <section
-            key={visit.visitId}
-            className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
-          >
-            <h3 className="text-base font-semibold text-gray-900">
-              Visit on {new Date(visit.visitDate).toLocaleDateString()}
-            </h3>
-            <div className="mt-2 space-y-1 text-sm text-gray-700">
-              <p>
-                <span className="font-semibold">Doctor:</span> {visit.doctor.name}
-              </p>
-              {visit.diagnoses.length > 0 && (
-                <p>
-                  <span className="font-semibold">Diagnoses:</span>{' '}
-                  {visit.diagnoses.map((d) => d.diagnosis).join(', ')}
-                </p>
-              )}
-              {visit.medications.length > 0 && (
-                <p>
-                  <span className="font-semibold">Medications:</span>{' '}
-                  {visit.medications
-                    .map((m) =>
-                      m.dosage ? `${m.drugName} (${m.dosage})` : m.drugName,
-                    )
-                    .join(', ')}
-                </p>
-              )}
-              {visit.labResults.length > 0 && (
-                <p>
-                  <span className="font-semibold">Labs:</span>{' '}
-                  {visit.labResults
-                    .map(
-                      (l) =>
-                        `${l.testName} ${l.resultValue ?? ''}${l.unit ?? ''}`,
-                    )
-                    .join(', ')}
-                </p>
-              )}
-              {visit.observations.length > 0 && (
-                <p>
-                  <span className="font-semibold">Observations:</span>{' '}
-                  {visit.observations.map((o) => o.noteText).join('; ')}
-                </p>
-              )}
-            </div>
-          </section>
-        ))}
+      <div className="space-y-6">
+        {p.visits.map((visit) => {
+          const diagnoses = visit.diagnoses ?? [];
+          const medications = visit.medications ?? [];
+          const labs = visit.labResults ?? [];
+          const observations = visit.observations ?? [];
+
+          return (
+            <article
+              key={visit.visitId}
+              className="rounded-2xl border border-gray-200 bg-gray-50 p-6 shadow-sm"
+            >
+              <div className="flex flex-wrap justify-between gap-4">
+                <div>
+                  <div className="text-sm font-medium text-blue-600">{formatDate(visit.visitDate)}</div>
+                  <h3 className="mt-1 text-lg font-semibold text-gray-900">
+                    Visit with {visit.doctor.name}
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-500">{visit.doctor.department}</p>
+                </div>
+                <Link
+                  to={`/visits/${visit.visitId}`}
+                  className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+                >
+                  Open visit
+                </Link>
+              </div>
+
+              <div className="mt-5 grid gap-5 lg:grid-cols-2">
+                <div className="space-y-4">
+                  <div>
+                    <div className="text-sm font-semibold text-gray-900">Diagnoses</div>
+                    {diagnoses.length > 0 ? (
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {diagnoses.map((diag) => (
+                          <span
+                            key={diag.diagnosis}
+                            className="inline-flex items-center rounded-full bg-red-50 px-3 py-1 text-xs font-medium text-red-700"
+                          >
+                            {diag.diagnosis}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="mt-2 text-sm text-gray-500">No diagnoses recorded.</p>
+                    )}
+                  </div>
+
+                  <div>
+                    <div className="text-sm font-semibold text-gray-900">Medications</div>
+                    {medications.length > 0 ? (
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {medications.map((med, index) => {
+                          const display = med.dosage ? `${med.drugName} (${med.dosage})` : med.drugName;
+                          return (
+                            <span
+                              key={`${med.drugName}-${index}`}
+                              className="inline-flex items-center rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700"
+                            >
+                              {display}
+                            </span>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <p className="mt-2 text-sm text-gray-500">No medications documented.</p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="space-y-4">
+                  <div>
+                    <div className="text-sm font-semibold text-gray-900">Key labs</div>
+                    {labs.length > 0 ? (
+                      <div className="mt-2 space-y-3">
+                        {labs.map((lab, index) => {
+                          const value =
+                            lab.resultValue !== null && lab.resultValue !== undefined
+                              ? `${lab.resultValue}${lab.unit ? ` ${lab.unit}` : ''}`
+                              : 'Pending';
+                          return (
+                            <div
+                              key={`${lab.testName}-${lab.testDate ?? index}`}
+                              className="rounded-xl border border-blue-100 bg-blue-50 px-4 py-3"
+                            >
+                              <div className="text-sm font-semibold text-blue-700">{lab.testName}</div>
+                              <div className="mt-1 text-base font-semibold text-blue-900">{value}</div>
+                              {lab.testDate && (
+                                <div className="text-xs text-blue-600">
+                                  Collected {formatDate(lab.testDate)}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <p className="mt-2 text-sm text-gray-500">No lab highlights for this visit.</p>
+                    )}
+                  </div>
+
+                  <div>
+                    <div className="text-sm font-semibold text-gray-900">Observations</div>
+                    {observations.length > 0 ? (
+                      <ul className="mt-2 space-y-2 text-sm text-gray-700">
+                        {observations.map((obs) => (
+                          <li
+                            key={obs.obsId}
+                            className="rounded-lg border border-gray-200 bg-gray-100 px-4 py-3"
+                          >
+                            <div>{obs.noteText}</div>
+                            <div className="mt-1 text-xs text-gray-500">{formatDateTime(obs.createdAt)}</div>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="mt-2 text-sm text-gray-500">No recent clinician notes.</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </article>
+          );
+        })}
       </div>
     );
   }
 
   function renderVisits() {
-    if (visitsLoading) return <div className="mt-6">Loading visits...</div>;
-    if (!visits) return null;
+    if (visitsLoading) {
       return (
-        <div className="mt-5 space-y-5">
-          {visits.length === 0 ? (
-            <div>No visits found.</div>
-          ) : (
-            visits.map((v) => (
-            <section
-              key={v.visitId}
-              className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
+        <div className="flex items-center justify-center rounded-2xl border border-gray-100 bg-gray-50 py-16">
+          <div className="flex flex-col items-center gap-3">
+            <SearchIcon className="h-8 w-8 animate-spin text-blue-500" />
+            <p className="text-sm text-gray-600">Loading visit history...</p>
+          </div>
+        </div>
+      );
+    }
+
+    if (visitsError) {
+      return (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700">
+          {visitsError}
+        </div>
+      );
+    }
+
+    if (!visits) {
+      return null;
+    }
+
+    if (visits.length === 0) {
+      return (
+        <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center">
+          <PatientsIcon className="h-12 w-12 text-gray-300" />
+          <p className="text-sm font-medium text-gray-600">No visits recorded in the system.</p>
+          {id && (
+            <Link
+              to={`/patients/${id}/visits/new`}
+              className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
             >
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <h3 className="text-base font-semibold text-gray-900">
-                    Visit on {new Date(v.visitDate).toLocaleDateString()}
-                  </h3>
-                  <div className="mt-2 space-y-1 text-sm text-gray-700">
-                    <p>
-                      <span className="font-semibold">Doctor:</span> {v.doctor.name}
-                    </p>
-                    <p>
-                      <span className="font-semibold">Department:</span> {v.department}
-                    </p>
-                    {v.reason && (
-                      <p>
-                        <span className="font-semibold">Reason:</span> {v.reason}
-                      </p>
-                    )}
-                  </div>
-                </div>
-                <div className="shrink-0">
-                  <Link
-                    to={`/visits/${v.visitId}`}
-                    className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  >
-                    View
-                  </Link>
+              Add visit
+            </Link>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-4">
+        {visits.map((visit) => (
+          <article
+            key={visit.visitId}
+            className="rounded-2xl border border-gray-200 bg-gray-50 p-5 shadow-sm"
+          >
+            <div className="flex flex-wrap justify-between gap-4">
+              <div>
+                <div className="text-sm font-medium text-blue-600">{formatDate(visit.visitDate)}</div>
+                <h3 className="mt-1 text-lg font-semibold text-gray-900">
+                  Visit with {visit.doctor.name}
+                </h3>
+                <div className="mt-2 flex flex-wrap gap-2 text-xs font-medium">
+                  <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-blue-600">
+                    {visit.department}
+                  </span>
+                  {visit.reason && (
+                    <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-gray-600">
+                      {visit.reason}
+                    </span>
+                  )}
                 </div>
               </div>
-            </section>
-          ))
-        )}
+              <Link
+                to={`/visits/${visit.visitId}`}
+                className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+              >
+                View visit
+              </Link>
+            </div>
+          </article>
+        ))}
       </div>
     );
   }
 
+  const contact = patient?.contact?.trim() || 'Not provided';
+  const coverage = patient?.insurance?.trim() || 'Self-pay';
+  const gender = formatGender(patient?.gender);
+  const age = patient ? calculateAge(patient.dob) : null;
+  const lastVisit = patient?.visits?.[0] ?? null;
+
   return (
-      <div className="p-4 md:p-6">
-        <div className="mx-auto max-w-4xl rounded-2xl bg-white shadow-xl p-5 md:p-7">
-          <div className="flex items-start justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900">
-                {patient.name}
-              </h1>
-              <p className="mt-1 text-sm text-gray-700">
-                <span className="font-semibold">DOB:</span>{' '}
-                {new Date(patient.dob).toLocaleDateString()}
-              </p>
-              <p className="mt-1 text-sm text-gray-700">
-                <span className="font-semibold">Insurance:</span>{' '}
-                {patient.insurance || ''}
-              </p>
-            </div>
-            <div className="mt-4 shrink-0">
-              <Link
-                to={`/patients/${id}/visits/new`}
-                className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700"
-              >
-                Add Visit
-              </Link>
-            </div>
+    <DashboardLayout
+      title={patient?.name ?? 'Patient Profile'}
+      subtitle={subtitle}
+      activeItem="patients"
+      headerChildren={headerActions}
+    >
+      {loading ? (
+        <div className="flex justify-center">
+          <div className="flex flex-col items-center gap-3 rounded-2xl bg-white p-10 shadow-sm">
+            <SearchIcon className="h-10 w-10 animate-spin text-blue-500" />
+            <p className="text-sm font-medium text-gray-600">Loading patient record...</p>
           </div>
-
-        <div className="mt-4 border-b border-gray-200">
-          <nav role="tablist" className="flex gap-6">
-            <button
-              role="tab"
-              aria-selected={activeTab === 'summary'}
-              onClick={() => setActiveTab('summary')}
-              className={
-                '-mb-px px-1 pb-3 text-sm font-medium focus:outline-none ' +
-                (activeTab === 'summary'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-800 border-b-2 border-transparent hover:border-gray-300')
-              }
-            >
-              Summary
-            </button>
-            <button
-              role="tab"
-              aria-selected={activeTab === 'visits'}
-              onClick={() => setActiveTab('visits')}
-              className={
-                '-mb-px px-1 pb-3 text-sm font-medium focus:outline-none ' +
-                (activeTab === 'visits'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-800 border-b-2 border-transparent hover:border-gray-300')
-              }
-            >
-              Visits
-            </button>
-          </nav>
         </div>
+      ) : error ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-700 shadow-sm">
+          <p className="text-sm font-semibold">{error}</p>
+          <Link
+            to="/patients"
+            className="mt-4 inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-medium text-red-600 shadow-sm hover:bg-red-100"
+          >
+            Back to patient directory
+          </Link>
+        </div>
+      ) : patient ? (
+        <div className="space-y-6">
+          <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="flex flex-wrap justify-between gap-6">
+              <div>
+                <p className="text-sm font-medium text-blue-600">Patient Overview</p>
+                <h2 className="mt-1 text-2xl font-semibold text-gray-900">{patient.name}</h2>
+                <p className="mt-1 text-sm text-gray-500">Patient ID: {patient.patientId}</p>
+                <p className="mt-2 text-sm text-gray-600">
+                  Review demographic details and the latest clinical activity for this patient.
+                </p>
+              </div>
+              <div className="min-w-[12rem] rounded-xl bg-gray-50 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Primary contact
+                </div>
+                <div className="mt-2 text-base font-semibold text-gray-900">{contact}</div>
+              </div>
+            </div>
+            <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {[
+                { label: 'Date of Birth', value: formatDate(patient.dob) },
+                { label: 'Age', value: age !== null ? `${age} yrs` : '—' },
+                { label: 'Insurance', value: coverage },
+                { label: 'Gender', value: gender },
+              ].map((stat) => (
+                <div
+                  key={stat.label}
+                  className="rounded-xl border border-gray-100 bg-gray-50 p-4"
+                >
+                  <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    {stat.label}
+                  </div>
+                  <div className="mt-2 text-base font-semibold text-gray-900">{stat.value}</div>
+                </div>
+              ))}
+            </div>
+            <div
+              className={`mt-6 rounded-xl px-4 py-3 text-sm ${
+                lastVisit
+                  ? 'bg-blue-50 text-blue-700'
+                  : 'border border-dashed border-blue-200 text-blue-600'
+              }`}
+            >
+              {lastVisit
+                ? `Last visit on ${formatDate(lastVisit.visitDate)} with ${lastVisit.doctor.name} (${lastVisit.doctor.department}).`
+                : 'No recorded visits yet. Add a visit to begin the clinical timeline.'}
+            </div>
+          </section>
 
-          {activeTab === 'summary' ? renderSummary(patient) : renderVisits()}
-        <BackButton />
-      </div>
-    </div>
+          <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">Clinical Timeline</h2>
+                <p className="mt-1 text-sm text-gray-600">
+                  Explore recent encounters and the complete visit history.
+                </p>
+              </div>
+              <nav
+                role="tablist"
+                aria-label="Patient detail tabs"
+                className="inline-flex rounded-full bg-gray-100 p-1 text-sm font-medium"
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={activeTab === 'summary'}
+                  onClick={() => handleTabChange('summary')}
+                  className={`rounded-full px-4 py-2 transition ${
+                    activeTab === 'summary'
+                      ? 'bg-white text-blue-600 shadow'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  Care Summary
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={activeTab === 'visits'}
+                  onClick={() => handleTabChange('visits')}
+                  className={`rounded-full px-4 py-2 transition ${
+                    activeTab === 'visits'
+                      ? 'bg-white text-blue-600 shadow'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  Visit History
+                </button>
+              </nav>
+            </div>
+
+            <div className="mt-6">
+              {activeTab === 'summary' ? renderSummary(patient) : renderVisits()}
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </DashboardLayout>
   );
 }
-

--- a/client/src/pages/VisitDetail.tsx
+++ b/client/src/pages/VisitDetail.tsx
@@ -1,5 +1,8 @@
+
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+import { PatientsIcon, SearchIcon } from '../components/icons';
 import {
   addObservation,
   getPatient,
@@ -9,201 +12,430 @@ import {
   type VisitDetail as VisitDetailType,
 } from '../api/client';
 
+function formatDate(value: string | Date | null | undefined) {
+  if (!value) return '—';
+  const date = typeof value === 'string' ? new Date(value) : value;
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleDateString();
+}
+
+function formatDateTime(value: string | Date | null | undefined) {
+  if (!value) return '—';
+  const date = typeof value === 'string' ? new Date(value) : value;
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString();
+}
+
+function calculateAge(dob: string) {
+  const birth = new Date(dob);
+  if (Number.isNaN(birth.getTime())) return null;
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+function formatGender(gender?: string | null) {
+  if (!gender) return 'Not recorded';
+  const normalized = gender.toLowerCase();
+  if (normalized === 'm') return 'Male';
+  if (normalized === 'f') return 'Female';
+  return gender;
+}
+
+function buildObservationVitals(observation: Observation) {
+  const vitals: string[] = [];
+  const hasBloodPressure =
+    observation.bpSystolic !== undefined || observation.bpDiastolic !== undefined;
+  if (hasBloodPressure) {
+    const systolic = observation.bpSystolic ?? '—';
+    const diastolic = observation.bpDiastolic ?? '—';
+    vitals.push(`BP ${systolic}/${diastolic} mmHg`);
+  }
+  if (observation.heartRate !== undefined) {
+    vitals.push(`HR ${observation.heartRate} bpm`);
+  }
+  if (observation.temperatureC !== undefined) {
+    vitals.push(`Temp ${observation.temperatureC} °C`);
+  }
+  if (observation.spo2 !== undefined) {
+    vitals.push(`SpO₂ ${observation.spo2}%`);
+  }
+  if (observation.bmi !== undefined) {
+    vitals.push(`BMI ${observation.bmi}`);
+  }
+  return vitals;
+}
+
 export default function VisitDetail() {
   const { id } = useParams<{ id: string }>();
   const [visit, setVisit] = useState<VisitDetailType | null>(null);
   const [patient, setPatient] = useState<Patient | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    async function load() {
-      if (!id) return;
+    const visitId = id;
+    if (!visitId) {
+      setError('Visit identifier is missing.');
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setVisit(null);
+    setPatient(null);
+
+    async function load(targetVisitId: string) {
       try {
-        const v = await getVisit(id);
+        const v = await getVisit(targetVisitId);
+        if (cancelled) return;
         setVisit(v);
         const p = await getPatient(v.patientId);
-        setPatient(p as Patient);
+        if (!cancelled) {
+          setPatient(p as Patient);
+        }
       } catch (err) {
         console.error(err);
+        if (!cancelled) {
+          setError('Unable to load visit details right now.');
+        }
       } finally {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     }
-    load();
+
+    load(visitId);
+
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
   async function handleAddObservation() {
-    if (!id) return;
+    const visitId = id;
+    if (!visitId) return;
     const note = window.prompt('Enter observation note');
     if (!note) return;
     try {
-      const obs = await addObservation(id, { noteText: note });
-      setVisit((v) =>
-        v ? { ...v, observations: [obs, ...v.observations] } : v,
-      );
+      const obs = await addObservation(visitId, { noteText: note });
+      setVisit((current) => (current ? { ...current, observations: [obs, ...current.observations] } : current));
     } catch (err) {
       console.error(err);
+      window.alert('Unable to add an observation at this time.');
     }
   }
 
-  if (loading)
-    return (
-      <div className="p-4 md:p-6">
-        <div className="mx-auto max-w-3xl rounded-2xl bg-white shadow-xl p-5 md:p-7">
-          Loading...
-        </div>
-      </div>
-    );
+  const headerActions = visit ? (
+    <div className="flex flex-col gap-2 md:flex-row md:items-center">
+      <Link
+        to={`/patients/${visit.patientId}`}
+        className="inline-flex items-center justify-center rounded-full border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+      >
+        Patient Profile
+      </Link>
+    </div>
+  ) : undefined;
 
-  if (!visit || !patient)
-    return (
-      <div className="p-4 md:p-6">
-        <div className="mx-auto max-w-3xl rounded-2xl bg-white shadow-xl p-5 md:p-7">
-          Visit not found
-        </div>
-      </div>
-    );
+  const subtitle = visit
+    ? `Visit on ${formatDate(visit.visitDate)} with ${visit.doctor.name}`
+    : loading
+      ? 'Loading visit details...'
+      : error ?? 'Visit details unavailable.';
 
-  const vitalsSource: Observation | undefined = visit.observations.find(
-    (o) =>
-      o.bpSystolic !== undefined ||
-      o.bpDiastolic !== undefined ||
-      o.heartRate !== undefined ||
-      o.temperatureC !== undefined ||
-      o.spo2 !== undefined ||
-      o.bmi !== undefined,
+  const coverage = patient?.insurance?.trim() || 'Self-pay';
+  const gender = formatGender(patient?.gender);
+  const contact = patient?.contact?.trim() || 'Not provided';
+  const age = patient ? calculateAge(patient.dob) : null;
+
+  const vitalsSource = visit?.observations.find(
+    (observation) =>
+      observation.bpSystolic !== undefined ||
+      observation.bpDiastolic !== undefined ||
+      observation.heartRate !== undefined ||
+      observation.temperatureC !== undefined ||
+      observation.spo2 !== undefined ||
+      observation.bmi !== undefined,
   );
 
-  const vitals = {
-    bpSystolic: vitalsSource?.bpSystolic ?? 'N/A',
-    bpDiastolic: vitalsSource?.bpDiastolic ?? 'N/A',
-    heartRate: vitalsSource?.heartRate ?? 'N/A',
-    tempC: vitalsSource?.temperatureC ?? 'N/A',
-    spo2: vitalsSource?.spo2 ?? 'N/A',
-    bmi: vitalsSource?.bmi ?? 'N/A',
-  };
+  const vitalMetrics = [
+    {
+      label: 'Blood Pressure',
+      value:
+        vitalsSource && (vitalsSource.bpSystolic !== undefined || vitalsSource.bpDiastolic !== undefined)
+          ? `${vitalsSource.bpSystolic ?? '—'}/${vitalsSource.bpDiastolic ?? '—'} mmHg`
+          : 'N/A',
+    },
+    {
+      label: 'Heart Rate',
+      value:
+        vitalsSource?.heartRate !== undefined ? `${vitalsSource.heartRate} bpm` : 'N/A',
+    },
+    {
+      label: 'Temperature',
+      value:
+        vitalsSource?.temperatureC !== undefined ? `${vitalsSource.temperatureC} °C` : 'N/A',
+    },
+    {
+      label: 'SpO₂',
+      value: vitalsSource?.spo2 !== undefined ? `${vitalsSource.spo2}%` : 'N/A',
+    },
+    {
+      label: 'BMI',
+      value: vitalsSource?.bmi !== undefined ? `${vitalsSource.bmi}` : 'N/A',
+    },
+  ];
 
   return (
-    <div className="bg-gray-50 min-h-screen p-4 md:p-6">
-      <div className="mx-auto max-w-3xl rounded-2xl bg-white shadow-xl p-5 md:p-7">
-        <h1 className="text-2xl font-semibold text-gray-900">{patient.name}</h1>
-        <p className="mt-1 text-sm text-gray-700">
-          <span className="font-semibold">DOB:</span> {patient.dob}
-        </p>
-        <p className="mt-1 text-sm text-gray-700">
-          <span className="font-semibold">Insurance:</span> {patient.insurance}
-        </p>
-
-        <h2 className="mt-6 text-lg font-semibold text-gray-900">Visit Detail</h2>
-        <p className="mt-1 text-sm text-gray-700">
-          <span className="font-semibold">Date:</span>{' '}
-          {new Date(visit.visitDate).toLocaleDateString()}
-        </p>
-        <p className="mt-1 text-sm text-gray-700">
-          <span className="font-semibold">Department:</span> {visit.department}
-        </p>
-        <p className="mt-1 text-sm text-gray-700">
-          <span className="font-semibold">Doctor:</span> {visit.doctor.name}
-        </p>
-        {visit.reason && (
-          <p className="mt-1 text-sm text-gray-700">
-            <span className="font-semibold">Reason:</span> {visit.reason}
-          </p>
-        )}
-
-        <h3 className="mt-6 text-lg font-semibold text-gray-900">Diagnoses</h3>
-        <div className="mt-2 rounded-lg bg-gray-100 px-4 py-3 text-sm text-gray-800">
-          {visit.diagnoses.map((d) => d.diagnosis).join(', ')}
+    <DashboardLayout
+      title={patient ? patient.name : 'Visit Detail'}
+      subtitle={subtitle}
+      activeItem="patients"
+      headerChildren={headerActions}
+    >
+      {loading ? (
+        <div className="flex justify-center">
+          <div className="flex flex-col items-center gap-3 rounded-2xl bg-white p-10 shadow-sm">
+            <SearchIcon className="h-10 w-10 animate-spin text-blue-500" />
+            <p className="text-sm font-medium text-gray-600">Loading visit record...</p>
+          </div>
         </div>
-
-        <h3 className="mt-6 text-lg font-semibold text-gray-900">Medications</h3>
-        <div className="mt-2 rounded-lg bg-gray-100 px-4 py-3 text-sm text-gray-800">
-          {visit.medications
-            .map((m) => (m.dosage ? `${m.drugName} (${m.dosage})` : m.drugName))
-            .join(', ')}
+      ) : error ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-700 shadow-sm">
+          <p className="text-sm font-semibold">{error}</p>
+          <Link
+            to="/patients"
+            className="mt-4 inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-medium text-red-600 shadow-sm hover:bg-red-100"
+          >
+            Back to patient directory
+          </Link>
         </div>
-
-        <h3 className="mt-6 text-lg font-semibold text-gray-900">Labs</h3>
-        <div className="mt-2 rounded-lg bg-gray-100 px-4 py-3 text-sm text-gray-800">
-          {visit.labResults
-            .map(
-              (l) =>
-                `${l.testName} ${l.resultValue ?? ''}${l.unit ?? ''}`.trim(),
-            )
-            .join(', ')}
-        </div>
-
-        <h3 className="mt-6 text-lg font-semibold text-gray-900">Observations</h3>
-        <div className="mt-2 space-y-3">
-          {visit.observations.map((o) => (
-            <div
-              key={o.obsId}
-              className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
-            >
-              <div className="text-sm font-medium text-gray-900">
-                {o.noteText}
+      ) : visit && patient ? (
+        <div className="space-y-6">
+          <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+              <div>
+                <p className="text-sm font-medium text-blue-600">Visit Overview</p>
+                <h2 className="mt-1 text-2xl font-semibold text-gray-900">{formatDate(visit.visitDate)}</h2>
+                <p className="mt-1 text-sm text-gray-600">
+                  {visit.reason || 'No visit reason documented.'}
+                </p>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium">
+                  <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-blue-600">
+                    {visit.department}
+                  </span>
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-gray-600">
+                    Dr. {visit.doctor.name}
+                  </span>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium text-gray-600">
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1">
+                    Patient ID: {patient.patientId}
+                  </span>
+                  <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1">
+                    Visit ID: {visit.visitId}
+                  </span>
+                </div>
               </div>
-              <div className="mt-1 text-xs text-gray-500">
-                {new Date(o.createdAt).toLocaleString()}
+              <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
+                <div className="text-sm font-semibold text-gray-900">Patient Snapshot</div>
+                <dl className="mt-3 space-y-3 text-sm text-gray-600">
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-gray-500">Date of Birth</dt>
+                    <dd className="font-semibold text-gray-900">{formatDate(patient.dob)}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-gray-500">Age</dt>
+                    <dd className="font-semibold text-gray-900">{age !== null ? `${age} yrs` : '—'}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-gray-500">Gender</dt>
+                    <dd className="font-semibold text-gray-900">{gender}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-gray-500">Insurance</dt>
+                    <dd className="font-semibold text-gray-900">{coverage}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-gray-500">Contact</dt>
+                    <dd className="text-right font-semibold text-gray-900">{contact}</dd>
+                  </div>
+                </dl>
               </div>
             </div>
-          ))}
+          </section>
+
+          <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">Diagnoses</h3>
+                <p className="mt-1 text-sm text-gray-600">Conditions assessed during this visit.</p>
+              </div>
+            </div>
+            {visit.diagnoses.length > 0 ? (
+              <div className="mt-4 flex flex-wrap gap-2">
+                {visit.diagnoses.map((diagnosis, index) => (
+                  <span
+                    key={`${diagnosis.diagnosis}-${index}`}
+                    className="inline-flex items-center rounded-full bg-red-50 px-3 py-1 text-sm font-medium text-red-700"
+                  >
+                    {diagnosis.diagnosis}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-gray-500">No diagnoses captured for this visit.</p>
+            )}
+          </section>
+
+          <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">Medications</h3>
+                <p className="mt-1 text-sm text-gray-600">Therapies prescribed during the encounter.</p>
+              </div>
+            </div>
+            {visit.medications.length > 0 ? (
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                {visit.medications.map((medication, index) => (
+                  <div
+                    key={`${medication.drugName}-${index}`}
+                    className="rounded-xl border border-green-100 bg-green-50 p-4"
+                  >
+                    <div className="text-sm font-semibold text-green-700">{medication.drugName}</div>
+                    {medication.dosage && (
+                      <div className="mt-1 text-sm text-green-700">{medication.dosage}</div>
+                    )}
+                    {medication.instructions && (
+                      <div className="mt-2 text-xs text-green-600">{medication.instructions}</div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-gray-500">No medications recorded for this visit.</p>
+            )}
+          </section>
+
+          <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">Lab Results</h3>
+                <p className="mt-1 text-sm text-gray-600">Key diagnostic tests captured during this visit.</p>
+              </div>
+            </div>
+            {visit.labResults.length > 0 ? (
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                {visit.labResults.map((lab, index) => {
+                  const value =
+                    lab.resultValue !== null && lab.resultValue !== undefined
+                      ? `${lab.resultValue}${lab.unit ? ` ${lab.unit}` : ''}`
+                      : 'Pending';
+                  return (
+                    <div
+                      key={`${lab.testName}-${lab.testDate ?? index}`}
+                      className="rounded-xl border border-blue-100 bg-blue-50 p-4"
+                    >
+                      <div className="text-sm font-semibold text-blue-700">{lab.testName}</div>
+                      <div className="mt-1 text-lg font-semibold text-blue-900">{value}</div>
+                      {lab.testDate && (
+                        <div className="mt-2 text-xs text-blue-600">Collected {formatDate(lab.testDate)}</div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-gray-500">No lab results recorded for this visit.</p>
+            )}
+          </section>
+
+          <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">Observations</h3>
+                <p className="mt-1 text-sm text-gray-600">Clinician notes and vitals captured during the visit.</p>
+              </div>
+              <button
+                type="button"
+                onClick={handleAddObservation}
+                className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+              >
+                Add Observation
+              </button>
+            </div>
+            {visit.observations.length > 0 ? (
+              <div className="mt-4 space-y-3">
+                {visit.observations.map((observation) => {
+                  const vitals = buildObservationVitals(observation);
+                  return (
+                    <div
+                      key={observation.obsId}
+                      className="rounded-xl border border-gray-200 bg-gray-50 p-4"
+                    >
+                      <div className="text-sm font-medium text-gray-900">{observation.noteText}</div>
+                      <div className="mt-1 text-xs text-gray-500">{formatDateTime(observation.createdAt)}</div>
+                      {vitals.length > 0 && (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {vitals.map((item) => (
+                            <span
+                              key={item}
+                              className="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700"
+                            >
+                              {item}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="mt-4 flex flex-col items-center gap-3 rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center">
+                <PatientsIcon className="h-12 w-12 text-gray-300" />
+                <p className="text-sm font-medium text-gray-600">No observations recorded for this visit.</p>
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">Key Vitals</h3>
+                <p className="mt-1 text-sm text-gray-600">Latest vitals captured during the visit.</p>
+              </div>
+            </div>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {vitalMetrics.map((metric) => (
+                <div
+                  key={metric.label}
+                  className="rounded-xl border border-gray-100 bg-gray-50 p-4"
+                >
+                  <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    {metric.label}
+                  </div>
+                  <div className="mt-2 text-base font-semibold text-gray-900">{metric.value}</div>
+                </div>
+              ))}
+            </div>
+            {!vitalsSource && (
+              <p className="mt-3 text-xs text-gray-500">Vitals will appear here once recorded for this visit.</p>
+            )}
+          </section>
         </div>
-
-        <button
-          type="button"
-          onClick={handleAddObservation}
-          className="mt-2 text-sm font-medium text-blue-600 hover:text-blue-700"
-        >
-          Add Observation
-        </button>
-
-        <div className="mt-6 grid gap-3 sm:grid-cols-2 md:grid-cols-3">
-          <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-            <div className="text-sm font-semibold text-gray-800">BP Systolic</div>
-            <div className="mt-1 text-lg font-semibold text-gray-900">
-              {vitals.bpSystolic}
-            </div>
-          </div>
-          <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-            <div className="text-sm font-semibold text-gray-800">
-              BP Diastolic
-            </div>
-            <div className="mt-1 text-lg font-semibold text-gray-900">
-              {vitals.bpDiastolic}
-            </div>
-          </div>
-          <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-            <div className="text-sm font-semibold text-gray-800">Heart Rate</div>
-            <div className="mt-1 text-lg font-semibold text-gray-900">
-              {vitals.heartRate}
-            </div>
-          </div>
-          <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-            <div className="text-sm font-semibold text-gray-800">Temp C</div>
-            <div className="mt-1 text-lg font-semibold text-gray-900">
-              {vitals.tempC}
-            </div>
-          </div>
-          <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-            <div className="text-sm font-semibold text-gray-800">SpO2</div>
-            <div className="mt-1 text-lg font-semibold text-gray-900">
-              {vitals.spo2}
-            </div>
-          </div>
-          <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-            <div className="text-sm font-semibold text-gray-800">BMI</div>
-            <div className="mt-1 text-lg font-semibold text-gray-900">
-              {vitals.bmi}
-            </div>
-          </div>
+      ) : (
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 text-gray-700 shadow-sm">
+          Visit not found.
         </div>
-
-        <p className="mt-4 text-sm text-gray-500">
-          My previous notes for this patient (before this visit)
-        </p>
-      </div>
-    </div>
+      )}
+    </DashboardLayout>
   );
 }
-


### PR DESCRIPTION
## Summary
- add optional gender and contact fields to the patient API type so demographic data can surface in the UI
- rebuild the patient detail screen with DashboardLayout, hero metrics, and polished summary/visit history views to match the dashboard styling
- refresh the visit detail experience with snapshot cards, richer observations, labs, medications, and vitals sections

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68cd0ba4853c832ead37c9f295056608