### PR TITLE
Add appointment and scheduling models

### DIFF
--- a/prisma/migrations/20250119000003_appointments_init/migration.sql
+++ b/prisma/migrations/20250119000003_appointments_init/migration.sql
@@ -1,0 +1,56 @@
+-- CreateEnum
+CREATE TYPE "AppointmentStatus" AS ENUM ('Scheduled', 'CheckedIn', 'InProgress', 'Completed', 'Cancelled');
+
+-- CreateTable
+CREATE TABLE "Appointment" (
+    "appointmentId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "patientId" UUID NOT NULL,
+    "doctorId" UUID NOT NULL,
+    "department" TEXT NOT NULL,
+    "date" TIMESTAMPTZ(3) NOT NULL,
+    "startTimeMin" INTEGER NOT NULL,
+    "endTimeMin" INTEGER NOT NULL,
+    "reason" TEXT,
+    "location" TEXT,
+    "status" "AppointmentStatus" NOT NULL DEFAULT 'Scheduled',
+    "cancelReason" TEXT,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Appointment_pkey" PRIMARY KEY ("appointmentId"),
+    CONSTRAINT "Appointment_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("patientId") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Appointment_doctorId_fkey" FOREIGN KEY ("doctorId") REFERENCES "Doctor"("doctorId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "DoctorAvailability" (
+    "availabilityId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "doctorId" UUID NOT NULL,
+    "dayOfWeek" INTEGER NOT NULL,
+    "startMin" INTEGER NOT NULL,
+    "endMin" INTEGER NOT NULL,
+    CONSTRAINT "DoctorAvailability_pkey" PRIMARY KEY ("availabilityId"),
+    CONSTRAINT "DoctorAvailability_doctorId_fkey" FOREIGN KEY ("doctorId") REFERENCES "Doctor"("doctorId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "DoctorBlackout" (
+    "blackoutId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "doctorId" UUID NOT NULL,
+    "startAt" TIMESTAMPTZ(3) NOT NULL,
+    "endAt" TIMESTAMPTZ(3) NOT NULL,
+    "reason" TEXT,
+    CONSTRAINT "DoctorBlackout_pkey" PRIMARY KEY ("blackoutId"),
+    CONSTRAINT "DoctorBlackout_doctorId_fkey" FOREIGN KEY ("doctorId") REFERENCES "Doctor"("doctorId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Appointment_doctorId_date_startTimeMin_endTimeMin_idx" ON "Appointment"("doctorId", "date", "startTimeMin", "endTimeMin");
+
+-- CreateIndex
+CREATE INDEX "Appointment_patientId_date_idx" ON "Appointment"("patientId", "date");
+
+-- CreateIndex
+CREATE INDEX "DoctorAvailability_doctorId_dayOfWeek_idx" ON "DoctorAvailability"("doctorId", "dayOfWeek");
+
+-- CreateIndex
+CREATE INDEX "DoctorBlackout_doctorId_startAt_endAt_idx" ON "DoctorBlackout"("doctorId", "startAt", "endAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,14 @@ enum Role {
   Auditor
 }
 
+enum AppointmentStatus {
+  Scheduled
+  CheckedIn
+  InProgress
+  Completed
+  Cancelled
+}
+
 model Patient {
   patientId    String   @id @default(uuid()) @db.Uuid
   name         String
@@ -44,6 +52,52 @@ model Doctor {
 
   visits       Visit[]
   observations Observation[]
+}
+
+model Appointment {
+  appointmentId String             @id @default(uuid()) @db.Uuid
+  patientId     String             @db.Uuid
+  doctorId      String             @db.Uuid
+  department    String
+  date          DateTime
+  startTimeMin  Int
+  endTimeMin    Int
+  reason        String?
+  location      String?
+  status        AppointmentStatus @default(Scheduled)
+  cancelReason  String?
+  createdAt     DateTime          @default(now())
+  updatedAt     DateTime          @updatedAt
+
+  patient Patient @relation(fields: [patientId], references: [patientId])
+  doctor  Doctor  @relation(fields: [doctorId], references: [doctorId])
+
+  @@index([doctorId, date, startTimeMin, endTimeMin])
+  @@index([patientId, date])
+}
+
+model DoctorAvailability {
+  availabilityId String @id @default(uuid()) @db.Uuid
+  doctorId       String @db.Uuid
+  dayOfWeek      Int
+  startMin       Int
+  endMin         Int
+
+  doctor Doctor @relation(fields: [doctorId], references: [doctorId])
+
+  @@index([doctorId, dayOfWeek])
+}
+
+model DoctorBlackout {
+  blackoutId String   @id @default(uuid()) @db.Uuid
+  doctorId   String   @db.Uuid
+  startAt    DateTime
+  endAt      DateTime
+  reason     String?
+
+  doctor Doctor @relation(fields: [doctorId], references: [doctorId])
+
+  @@index([doctorId, startAt, endAt])
 }
 
 model Visit {


### PR DESCRIPTION
## Summary
- add an `AppointmentStatus` enum and appointment scheduling models to the Prisma schema
- define doctor availability and blackout models with indexes to support scheduling lookups
- create the corresponding SQL migration for the new tables and enum

## Testing
- `npx prisma migrate dev -n "appointments_init"` *(fails: npm 403 Forbidden when downloading prisma package via proxy)*
- `npx prisma generate` *(fails: npm 403 Forbidden when downloading prisma package via proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68cd18d25490832e9f90bc7eb91efb1e