### PR TITLE
Add time and overlap utility helpers

### DIFF
--- a/src/utils/overlap.ts
+++ b/src/utils/overlap.ts
@@ -1,0 +1,8 @@
+export function isOverlap(
+  aStart: number,
+  aEnd: number,
+  bStart: number,
+  bEnd: number,
+): boolean {
+  return aStart < bEnd && aEnd > bStart;
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,25 @@
+export function toDateOnly(dateStr: string): Date {
+  return new Date(`${dateStr}T00:00:00Z`);
+}
+
+export function toMinutes(hhmm: string): number {
+  const [hours, minutes] = hhmm.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
+export function minutesToHHMM(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  const paddedHours = String(hours).padStart(2, "0");
+  const paddedMinutes = String(minutes).padStart(2, "0");
+
+  return `${paddedHours}:${paddedMinutes}`;
+}
+
+export function dayOfWeekUTC(date: Date): number {
+  return date.getUTCDay();
+}
+
+export function composeDateTime(date: Date, minutes: number): Date {
+  return new Date(date.getTime() + minutes * 60 * 1000);
+}


### PR DESCRIPTION
## Summary
- add reusable time conversion helpers covering date parsing, minute conversion, and UTC calculations
- introduce an interval overlap predicate for comparing minute ranges

## Testing
- `npm install` *(fails: 403 Forbidden when fetching registry packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1bc4e188832e94bd2b9e1bbd7240