### PR TITLE
feat: add appointments API routes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import insightsRouter from './modules/insights/index.js';
 import auditRouter from './modules/audit/index.js';
 import { docsRouter } from './docs/openapi.js';
 import authRouter from './modules/auth/index.js';
+import appointmentsRouter from './routes/appointments.js';
 
 export const apiRouter = Router();
 
@@ -27,6 +28,7 @@ apiRouter.use(observationsRouter);
 apiRouter.use('/insights', insightsRouter);
 apiRouter.use('/audit', auditRouter);
 apiRouter.use('/auth', authRouter);
+apiRouter.use('/appointments', appointmentsRouter);
 apiRouter.use(docsRouter);
 
 export default apiRouter;


### PR DESCRIPTION
## Summary
- add comprehensive appointments router with availability lookup, CRUD operations, status transitions, and visit creation on completion
- mount the new appointments router in the API server

## Testing
- npm run lint *(fails: ESLint config missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cd23836ca8832e9cffce5cd6fac8fd