### PR TITLE
Add appointment routes and API client scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 dist_client
+tsconfig.tsbuildinfo
 .env
 
 # Optional: lockfile generated during testing

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,9 @@ import Cohort from './pages/Cohort';
 import Settings from './pages/Settings';
 import Home from './pages/Home';
 import RegisterPatient from './pages/RegisterPatient';
+import AppointmentsPage from './pages/AppointmentsPage';
+import AppointmentForm from './pages/AppointmentForm';
+import AppointmentDetail from './pages/AppointmentDetail';
 import './styles/App.css';
 
 function App() {
@@ -28,6 +31,30 @@ function App() {
         element={
           <RouteGuard>
             <PatientDetail />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/appointments"
+        element={
+          <RouteGuard>
+            <AppointmentsPage />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/appointments/new"
+        element={
+          <RouteGuard>
+            <AppointmentForm />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/appointments/:id"
+        element={
+          <RouteGuard>
+            <AppointmentDetail />
           </RouteGuard>
         }
       />

--- a/client/src/api/appointments.ts
+++ b/client/src/api/appointments.ts
@@ -1,0 +1,150 @@
+import { fetchJSON } from './http';
+
+export type AppointmentStatus = 'Scheduled' | 'CheckedIn' | 'InProgress' | 'Completed' | 'Cancelled';
+export type AppointmentStatusPatch = 'CheckedIn' | 'InProgress' | 'Completed' | 'Cancelled';
+
+export interface AppointmentPatientSummary {
+  patientId: string;
+  name: string;
+}
+
+export interface AppointmentDoctorSummary {
+  doctorId: string;
+  name: string;
+  department: string;
+}
+
+export interface Appointment {
+  appointmentId: string;
+  patientId: string;
+  doctorId: string;
+  department: string;
+  date: string;
+  startTimeMin: number;
+  endTimeMin: number;
+  reason: string | null;
+  location: string | null;
+  status: AppointmentStatus;
+  cancelReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+  patient: AppointmentPatientSummary;
+  doctor: AppointmentDoctorSummary;
+}
+
+export interface AppointmentCreateRequest {
+  patientId: string;
+  doctorId: string;
+  department: string;
+  date: string;
+  startTimeMin: number;
+  endTimeMin: number;
+  reason?: string;
+  location?: string;
+}
+
+export interface AppointmentUpdateRequest {
+  patientId?: string;
+  doctorId?: string;
+  department?: string;
+  date?: string;
+  startTimeMin?: number;
+  endTimeMin?: number;
+  reason?: string;
+  location?: string;
+}
+
+export interface AppointmentStatusUpdateRequest {
+  status: AppointmentStatusPatch;
+  cancelReason?: string;
+}
+
+export interface AppointmentListParams {
+  date?: string;
+  from?: string;
+  to?: string;
+  doctorId?: string;
+  status?: AppointmentStatus;
+  limit?: number;
+  cursor?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface AppointmentListResponse {
+  data: Appointment[];
+  nextCursor?: string | null;
+}
+
+export interface AvailabilitySlot {
+  startMin: number;
+  endMin: number;
+}
+
+export interface AvailabilityResponse {
+  availability: AvailabilitySlot[];
+  blocked: AvailabilitySlot[];
+  freeSlots: AvailabilitySlot[];
+}
+
+export interface VisitCreatedResponse {
+  visitId: string;
+}
+
+type QueryValue = string | number | boolean | undefined;
+type QueryParams = Record<string, QueryValue>;
+
+function buildQuery(params?: QueryParams) {
+  if (!params) return '';
+
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      searchParams.set(key, String(value));
+    }
+  });
+
+  const query = searchParams.toString();
+  return query ? `?${query}` : '';
+}
+
+export function listAppointments(params?: AppointmentListParams): Promise<AppointmentListResponse> {
+  const query = buildQuery(params as QueryParams | undefined);
+  return fetchJSON(`/appointments${query}`);
+}
+
+export function getAppointment(id: string): Promise<Appointment> {
+  return fetchJSON(`/appointments/${id}`);
+}
+
+export function createAppointment(dto: AppointmentCreateRequest): Promise<Appointment> {
+  return fetchJSON('/appointments', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(dto),
+  });
+}
+
+export function updateAppointment(id: string, dto: AppointmentUpdateRequest): Promise<Appointment> {
+  return fetchJSON(`/appointments/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(dto),
+  });
+}
+
+export function patchStatus(
+  id: string,
+  statusDto: AppointmentStatusUpdateRequest,
+): Promise<Appointment | VisitCreatedResponse> {
+  return fetchJSON(`/appointments/${id}/status`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(statusDto),
+  });
+}
+
+export function getAvailability(doctorId: string, date: string): Promise<AvailabilityResponse> {
+  const query = buildQuery({ doctorId, date });
+  return fetchJSON(`/appointments/availability${query}`);
+}

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -22,7 +22,7 @@ type NavigationItem = {
 const navigation: NavigationItem[] = [
   { key: 'dashboard', name: 'Dashboard', icon: DashboardIcon, to: '/' },
   { key: 'patients', name: 'Patients', icon: PatientsIcon, to: '/patients' },
-  { key: 'appointments', name: 'Appointments', icon: CalendarIcon },
+  { key: 'appointments', name: 'Appointments', icon: CalendarIcon, to: '/appointments' },
   { key: 'reports', name: 'Reports', icon: ReportsIcon },
   { key: 'settings', name: 'Settings', icon: SettingsIcon, to: '/settings' },
 ];

--- a/client/src/pages/AppointmentDetail.tsx
+++ b/client/src/pages/AppointmentDetail.tsx
@@ -1,0 +1,15 @@
+import { useParams } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+
+export default function AppointmentDetail() {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <DashboardLayout title="Appointment detail" activeItem="appointments">
+      <div className="rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center text-sm text-gray-500">
+        Appointment detail placeholder
+        {id ? ` for ${id}` : ''}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/src/pages/AppointmentForm.tsx
+++ b/client/src/pages/AppointmentForm.tsx
@@ -1,0 +1,11 @@
+import DashboardLayout from '../components/DashboardLayout';
+
+export default function AppointmentForm() {
+  return (
+    <DashboardLayout title="Schedule appointment" activeItem="appointments">
+      <div className="rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center text-sm text-gray-500">
+        Appointment form placeholder
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/src/pages/AppointmentsPage.tsx
+++ b/client/src/pages/AppointmentsPage.tsx
@@ -1,0 +1,40 @@
+import DashboardLayout from '../components/DashboardLayout';
+
+const filterPlaceholders = ['Date', 'Doctor', 'Status'];
+
+export default function AppointmentsPage() {
+  return (
+    <DashboardLayout
+      title="Appointments"
+      subtitle="Week and day calendar views with filters"
+      activeItem="appointments"
+    >
+      <div className="space-y-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="inline-flex overflow-hidden rounded-full border border-gray-200 bg-white shadow-sm">
+            <button type="button" className="bg-blue-600 px-4 py-2 text-sm font-medium text-white">
+              Week view
+            </button>
+            <button type="button" className="px-4 py-2 text-sm font-medium text-gray-500">
+              Day view
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {filterPlaceholders.map((filter) => (
+              <span
+                key={filter}
+                className="inline-flex items-center rounded-full border border-dashed border-gray-300 px-3 py-1 text-xs font-medium uppercase tracking-wide text-gray-500"
+              >
+                {filter} filter
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center text-sm text-gray-500">
+          Calendar view placeholder
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder appointments pages for list, creation, and detail views under new routes
- enable appointments navigation link and expose appointment API client helpers
- ignore generated TypeScript build info artifacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd60bc840c832e9ad7d103326adda3