### PR TITLE
Add Prisma scripts and scheduling walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ npm run prisma:migrate
 npm run seed:csv
 ```
 
+## Staff Walkthrough
+Try the scheduling workflow after seeding demo data:
+1. Create an appointment for **Dr Tan** today from **10:00–10:30**.
+2. Attempt to create another appointment for the same provider and timeslot — the system should block the double booking.
+3. Mark the original appointment as complete and verify that the visit appears in the visit list.
+
 ## API Docs
 The OpenAPI specification is served at `/api/docs/openapi.json`.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand",
     "lint": "eslint .",
     "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev"
+    "prisma:migrate": "prisma migrate dev",
+    "seed": "prisma db seed",
+    "reset:db": "prisma migrate reset --force",
+    "studio": "prisma studio"
   },
   "prisma": {
     "seed": "node prisma/seed.mjs"


### PR DESCRIPTION
## Summary
- add handy Prisma scripts for database seeding, reset, and Studio access
- document a staff scheduling walkthrough to validate double-booking prevention

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfb0078710832eb38477ac51c86bc3