### PR TITLE
Fix appointment status transition typing for Prisma transaction

### DIFF
--- a/src/types/appointments.ts
+++ b/src/types/appointments.ts
@@ -70,7 +70,19 @@ type VisitDelegate = {
   create: (args: any) => Promise<any>;
 };
 
+type BaseTransactionClient = Omit<
+  PrismaClient,
+  '$connect' | '$disconnect' | '$on' | '$transaction' | '$extends'
+>;
+
 export type AppPrismaClient = PrismaClient & {
+  appointment: AppointmentDelegate;
+  doctorAvailability: AvailabilityDelegate;
+  doctorBlackout: BlackoutDelegate;
+  visit: VisitDelegate;
+};
+
+export type AppPrismaTransactionClient = BaseTransactionClient & {
   appointment: AppointmentDelegate;
   doctorAvailability: AvailabilityDelegate;
   doctorBlackout: BlackoutDelegate;


### PR DESCRIPTION
## Summary
- ensure appointment status transition checks use a typed status when indexing the allowed transition map
- add an AppPrismaTransactionClient helper type and use it inside the completion transaction so Prisma delegates stay typed

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcors)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbd25a74c832ebf230d2c10962a26