### PR TITLE
Validate appointment date parsing and add tests

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,5 +1,39 @@
+import { BadRequestError } from './httpErrors.js';
+
+const DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
+
 export function toDateOnly(dateStr: string): Date {
-  return new Date(`${dateStr}T00:00:00Z`);
+  if (typeof dateStr !== 'string') {
+    throw new BadRequestError('Date must be a string in format YYYY-MM-DD');
+  }
+
+  const normalized = dateStr.trim();
+  const match = DATE_ONLY_REGEX.exec(normalized);
+
+  if (!match) {
+    throw new BadRequestError('Date must be in format YYYY-MM-DD');
+  }
+
+  const [, yearStr, monthStr, dayStr] = match;
+  const date = new Date(`${normalized}T00:00:00Z`);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new BadRequestError('Invalid calendar date');
+  }
+
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() + 1 !== month ||
+    date.getUTCDate() !== day
+  ) {
+    throw new BadRequestError('Invalid calendar date');
+  }
+
+  return date;
 }
 
 export function toMinutes(hhmm: string): number {

--- a/tests/appointments.test.ts
+++ b/tests/appointments.test.ts
@@ -108,6 +108,42 @@ describe('POST /api/appointments', () => {
   });
 });
 
+describe('GET /api/appointments', () => {
+  it('returns appointments for a specific date', async () => {
+    const creation = await request(app)
+      .post('/api/appointments')
+      .send({
+        patientId,
+        doctorId,
+        department: 'Cardiology',
+        date: appointmentDate,
+        startTimeMin: startOfDayMinutes,
+        endTimeMin: startOfDayMinutes + 30,
+        reason: 'Listed visit',
+      });
+
+    expect(creation.status).toBe(201);
+
+    const listRes = await request(app)
+      .get('/api/appointments')
+      .query({ date: appointmentDate, limit: '10' });
+
+    expect(listRes.status).toBe(200);
+    expect(Array.isArray(listRes.body.data)).toBe(true);
+    expect(listRes.body.data).toHaveLength(1);
+    expect(listRes.body.data[0].date).toContain(appointmentDate);
+  });
+
+  it('rejects invalid calendar dates', async () => {
+    const res = await request(app)
+      .get('/api/appointments')
+      .query({ date: '2025-02-30' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/invalid/i);
+  });
+});
+
 describe('PATCH /api/appointments/:id/status', () => {
   it('creates a visit when marking appointment completed', async () => {
     const createRes = await request(app)


### PR DESCRIPTION
## Summary
- ensure appointment date parsing rejects malformed or impossible calendar dates
- add API coverage for listing appointments and invalid date handling

## Testing
- npm test *(fails: Cannot find module '.../node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68cfc0f113ac832e9df9c88128ec2729