### PR TITLE
Handle proxied rate limiting and resilient availability lookup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,22 @@ if (
 
 export const app = express();
 app.disable('x-powered-by');
+
+const trustProxy = process.env.TRUST_PROXY;
+if (trustProxy) {
+  const normalizedTrustProxy =
+    trustProxy === 'true'
+      ? true
+      : trustProxy === 'false'
+        ? false
+        : Number.isNaN(Number(trustProxy))
+          ? trustProxy
+          : Number(trustProxy);
+  app.set('trust proxy', normalizedTrustProxy);
+} else {
+  app.set('trust proxy', 1);
+}
+
 app.use(
   helmet({
     frameguard: false,


### PR DESCRIPTION
## Summary
- configure Express to trust proxy headers (with optional override) so rate limiting can safely inspect client IPs
- add resilience to doctor availability lookups by catching missing relation errors and probing fallback table layouts
- normalize raw availability results to numeric ranges returned to the rest of the scheduling logic

## Testing
- npm test *(fails: jest dependency unavailable in sandbox environment)*
- npm run lint *(fails: repository lacks ESLint flat config in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc8e251a8832e95ae75859b393e58