### PR TITLE
Ensure Prisma client is generated before build/start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,11 @@
         "express-rate-limit": "^7",
         "helmet": "^7",
         "morgan": "^1",
-        "zod": "^3"
+        "zod": "^3",
+        "@prisma/client": "^6.15.0",
+        "prisma": "^6.15.0"
       },
       "devDependencies": {
-        "@prisma/client": "^6.15.0",
         "@types/jest": "^29",
         "@types/node": "^20.19.13",
         "@types/supertest": "^2",
@@ -26,7 +27,6 @@
         "dotenv": "^17.2.2",
         "eslint": "^9.35.0",
         "jest": "^29",
-        "prisma": "^6.15.0",
         "supertest": "^6",
         "ts-jest": "^29",
         "ts-node": "^10.9.2",
@@ -1799,7 +1799,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.15.0.tgz",
       "integrity": "sha512-wR2LXUbOH4cL/WToatI/Y2c7uzni76oNFND7+23ypLllBmIS8e3ZHhO+nud9iXSXKFt1SoM3fTZvHawg63emZw==",
-      "dev": true,
+      "dev": false,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1822,7 +1822,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.15.0.tgz",
       "integrity": "sha512-KMEoec9b2u6zX0EbSEx/dRpx1oNLjqJEBZYyK0S3TTIbZ7GEGoVyGyFRk4C72+A38cuPLbfQGQvgOD+gBErKlA==",
-      "dev": true,
+      "dev": false,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -1835,14 +1835,14 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.15.0.tgz",
       "integrity": "sha512-y7cSeLuQmyt+A3hstAs6tsuAiVXSnw9T55ra77z0nbNkA8Lcq9rNcQg6PI00by/+WnE/aMRJ/W7sZWn2cgIy1g==",
-      "dev": true,
+      "dev": false,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.15.0.tgz",
       "integrity": "sha512-opITiR5ddFJ1N2iqa7mkRlohCZqVSsHhRcc29QXeldMljOf4FSellLT0J5goVb64EzRTKcIDeIsJBgmilNcKxA==",
-      "dev": true,
+      "dev": false,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1856,14 +1856,14 @@
       "version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb.tgz",
       "integrity": "sha512-a/46aK5j6L3ePwilZYEgYDPrhBQ/n4gYjLxT5YncUTJJNRnTCVjPF86QdzUOLRdYjCLfhtZp9aum90W0J+trrg==",
-      "dev": true,
+      "dev": false,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.15.0.tgz",
       "integrity": "sha512-xcT5f6b+OWBq6vTUnRCc7qL+Im570CtwvgSj+0MTSGA1o9UDSKZ/WANvwtiRXdbYWECpyC3CukoG3A04VTAPHw==",
-      "dev": true,
+      "dev": false,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.15.0",
@@ -1875,7 +1875,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.15.0.tgz",
       "integrity": "sha512-Jbb+Xbxyp05NSR1x2epabetHiXvpO8tdN2YNoWoA/ZsbYyxxu/CO/ROBauIFuMXs3Ti+W7N7SJtWsHGaWte9Rg==",
-      "dev": true,
+      "dev": false,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.15.0"
@@ -6751,7 +6751,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.15.0.tgz",
       "integrity": "sha512-E6RCgOt+kUVtjtZgLQDBJ6md2tDItLJNExwI0XJeBc1FKL+Vwb+ovxXxuok9r8oBgsOXBA33fGDuE/0qDdCWqQ==",
-      "dev": true,
+      "dev": false,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "build": "tsc && cd client && npm install && npm run build",
     "start": "npm run migrate:deploy && node dist/index.js",
+    "prebuild": "prisma generate",
+    "prestart": "prisma generate",
     "postinstall": "prisma generate",
     "dev": "concurrently -k -n API,WEB \"tsx watch src/index.ts\" \"cd client && npm run dev\"",
     "dev:api": "tsx watch src/index.ts",
@@ -24,7 +26,6 @@
     "seed": "node prisma/seed.mjs"
   },
   "devDependencies": {
-    "@prisma/client": "^6.15.0",
     "@types/jest": "^29",
     "@types/node": "^20.19.13",
     "@types/supertest": "^2",
@@ -37,7 +38,6 @@
     "@types/express": "^4",
     "@types/cors": "^2",
     "@types/morgan": "^1",
-    "prisma": "^6.15.0",
     "supertest": "^6",
     "ts-jest": "^29",
     "ts-node": "^10.9.2",
@@ -46,6 +46,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
+    "@prisma/client": "^6.15.0",
     "bcrypt": "^5",
     "cors": "^2",
     "csv-parse": "^6.1.0",
@@ -53,6 +54,7 @@
     "express-rate-limit": "^7",
     "helmet": "^7",
     "morgan": "^1",
+    "prisma": "^6.15.0",
     "zod": "^3"
   }
 }


### PR DESCRIPTION
## Summary
- run `prisma generate` automatically before building and starting the API so the Prisma client is always up to date
- move Prisma packages into runtime dependencies to guarantee the CLI and generated client are available in production installs

## Testing
- not run (npm install is blocked in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68cfd83bf95c832e9eb98c244fec78fb