### PR TITLE
Fix Prisma relation definitions for appointments

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,7 @@ model Patient {
   createdAt    DateTime @default(now()) @db.Timestamptz(6)
   updatedAt    DateTime @default(now()) @updatedAt @db.Timestamptz(6)
 
+  appointments Appointment[]
   visits       Visit[]
   observations Observation[]
 }
@@ -50,6 +51,9 @@ model Doctor {
   department  String
   createdAt   DateTime @default(now())
 
+  appointments  Appointment[]
+  availabilities DoctorAvailability[]
+  blackouts      DoctorBlackout[]
   visits       Visit[]
   observations Observation[]
 }


### PR DESCRIPTION
## Summary
- add missing back-relations from patients and doctors to appointments and scheduling models so Prisma can validate the schema

## Testing
- npx prisma validate *(fails: npm 403 Forbidden when attempting to download prisma binary without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68cfda539a0c832e8530835c075d2902