### PR TITLE
Handle missing availability table prisma errors

### DIFF
--- a/src/services/appointmentService.ts
+++ b/src/services/appointmentService.ts
@@ -77,12 +77,17 @@ function normalizeAvailabilityValue(value: unknown): number {
 }
 
 function isMissingRelationOrColumnError(error: unknown): boolean {
-  if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2010') {
+  if (!(error instanceof Prisma.PrismaClientKnownRequestError)) {
+    return false;
+  }
+
+  if (error.code === 'P2010') {
     const meta = error.meta as { code?: string } | undefined;
     return meta?.code === '42P01' || meta?.code === '42703';
   }
 
-  return false;
+  // Prisma uses these codes when the queried table or column does not exist.
+  return error.code === 'P2021' || error.code === 'P2022';
 }
 
 async function queryAvailabilityFallback(


### PR DESCRIPTION
## Summary
- treat Prisma error codes P2021 and P2022 as missing schema objects when querying doctor availability
- ensure fallback raw SQL query runs when DoctorAvailability table is absent

## Testing
- npm test -- --runTestsByPath tests/appointments.test.ts *(fails: missing jest dependency before install)*
- npm install *(fails: registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdb9c2d40832ea8ea94696e942c68