### PR TITLE
Handle missing doctor blackout table

### DIFF
--- a/src/services/appointmentService.ts
+++ b/src/services/appointmentService.ts
@@ -165,22 +165,30 @@ export async function hasDoctorBlackout(
   const startAt = composeDateTime(date, startMin);
   const endAt = composeDateTime(date, endMin);
 
-  const blackout = await prisma.doctorBlackout.findFirst({
-    where: {
-      doctorId,
-      startAt: {
-        lt: endAt,
+  try {
+    const blackout = await prisma.doctorBlackout.findFirst({
+      where: {
+        doctorId,
+        startAt: {
+          lt: endAt,
+        },
+        endAt: {
+          gt: startAt,
+        },
       },
-      endAt: {
-        gt: startAt,
+      select: {
+        blackoutId: true,
       },
-    },
-    select: {
-      blackoutId: true,
-    },
-  });
+    });
 
-  return Boolean(blackout);
+    return Boolean(blackout);
+  } catch (error) {
+    if (isMissingRelationOrColumnError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
 }
 
 export async function hasDoctorOverlap(


### PR DESCRIPTION
## Summary
- add shared helpers to detect missing Prisma tables for appointments and doctor blackouts
- treat doctor blackout queries as optional so availability endpoints keep working when the table is missing
- make blackout overlap checks safely return false if the blackout table has not been migrated yet

## Testing
- npm test *(fails: missing local node_modules)*
- npm install *(fails: registry responded with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe0a86fec832e8e5d36bf2d2284a9