### PR TITLE
Run migrations before starting dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "dev": "concurrently -k -n API,WEB \"tsx watch src/index.ts\" \"cd client && npm run dev\"",
     "dev:api": "tsx watch src/index.ts",
     "dev:web": "cd client && npm run dev",
+    "predev": "npm run migrate:deploy",
+    "predev:api": "npm run migrate:deploy",
     "migrate": "prisma migrate deploy",
     "migrate:deploy": "prisma migrate deploy",
     "seed:csv": "tsx scripts/loadCsv.ts",


### PR DESCRIPTION
## Summary
- ensure both dev scripts run `prisma migrate deploy` before starting the API watchers so that required tables such as Appointment are created automatically

## Testing
- `npm run lint` *(fails: ESLint configuration file missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe2106260832e8fd992285ea1f229