### PR TITLE
Add default doctor availability and UI management

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -15,6 +15,20 @@ export interface Doctor {
   department: string;
 }
 
+export interface DoctorAvailabilitySlot {
+  availabilityId: string;
+  doctorId: string;
+  dayOfWeek: number;
+  startMin: number;
+  endMin: number;
+}
+
+export interface DoctorAvailabilityResponse {
+  doctorId: string;
+  availability: DoctorAvailabilitySlot[];
+  defaultAvailability: { startMin: number; endMin: number }[];
+}
+
 export interface Diagnosis {
   diagnosis: string;
 }
@@ -126,6 +140,21 @@ export interface CreateDoctorPayload {
 
 export async function createDoctor(payload: CreateDoctorPayload): Promise<Doctor> {
   return fetchJSON('/doctors', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export function listDoctorAvailability(doctorId: string): Promise<DoctorAvailabilityResponse> {
+  return fetchJSON(`/doctors/${doctorId}/availability`);
+}
+
+export function createDoctorAvailability(
+  doctorId: string,
+  payload: { dayOfWeek: number; startMin: number; endMin: number },
+): Promise<DoctorAvailabilitySlot> {
+  return fetchJSON(`/doctors/${doctorId}/availability`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),

--- a/client/src/context/SettingsProvider.tsx
+++ b/client/src/context/SettingsProvider.tsx
@@ -13,7 +13,7 @@ interface SettingsContextType {
   doctors: Doctor[];
   updateSettings: (data: { appName?: string; logo?: string | null }) => void;
   addUser: (user: UserAccount) => void;
-  addDoctor: (doctor: { name: string; department: string }) => Promise<void>;
+  addDoctor: (doctor: { name: string; department: string }) => Promise<Doctor>;
   widgetEnabled: boolean;
   setWidgetEnabled: (enabled: boolean) => void;
 }
@@ -71,6 +71,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const addDoctor = async (doctor: { name: string; department: string }) => {
     const created = await createDoctor(doctor);
     setDoctors((prev) => [...prev, created]);
+    return created;
   };
 
   return (

--- a/src/modules/doctors/index.ts
+++ b/src/modules/doctors/index.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
 import { requireAuth, requireRole, type AuthRequest } from '../auth/index.js';
+import { DEFAULT_AVAILABILITY_WINDOWS } from '../../services/appointmentService.js';
 
 const prisma = new PrismaClient();
 const router = Router();
@@ -15,6 +16,21 @@ const createSchema = z.object({
   name: z.string().min(1),
   department: z.string().min(1),
 });
+
+const doctorIdSchema = z.object({
+  doctorId: z.string().uuid({ message: 'doctorId must be a valid UUID' }),
+});
+
+const availabilitySchema = z
+  .object({
+    dayOfWeek: z.coerce.number().int().min(0).max(6),
+    startMin: z.coerce.number().int().min(0).max(24 * 60 - 1),
+    endMin: z.coerce.number().int().min(1).max(24 * 60),
+  })
+  .refine((data) => data.endMin > data.startMin, {
+    message: 'endMin must be greater than startMin',
+    path: ['endMin'],
+  });
 
 router.get('/', requireAuth, async (req: Request, res: Response) => {
   const parsed = querySchema.safeParse(req.query);
@@ -41,5 +57,94 @@ router.post('/', requireAuth, requireRole('Admin'), async (req: AuthRequest, res
   const doctor = await prisma.doctor.create({ data: parsed.data });
   res.status(201).json(doctor);
 });
+
+router.get(
+  '/:doctorId/availability',
+  requireAuth,
+  async (req: Request, res: Response) => {
+    const params = doctorIdSchema.safeParse(req.params);
+    if (!params.success) {
+      return res.status(400).json({ message: 'Invalid doctorId' });
+    }
+
+    const { doctorId } = params.data;
+
+    const doctor = await prisma.doctor.findUnique({
+      where: { doctorId },
+      select: { doctorId: true },
+    });
+
+    if (!doctor) {
+      return res.status(404).json({ message: 'Doctor not found' });
+    }
+
+    const availability = await prisma.doctorAvailability.findMany({
+      where: { doctorId },
+      orderBy: [{ dayOfWeek: 'asc' }, { startMin: 'asc' }],
+    });
+
+    res.json({
+      doctorId,
+      availability,
+      defaultAvailability: DEFAULT_AVAILABILITY_WINDOWS.map((window) => ({ ...window })),
+    });
+  }
+);
+
+router.post(
+  '/:doctorId/availability',
+  requireAuth,
+  requireRole('Admin'),
+  async (req: AuthRequest, res: Response) => {
+    const params = doctorIdSchema.safeParse(req.params);
+    if (!params.success) {
+      return res.status(400).json({ message: 'Invalid doctorId' });
+    }
+
+    const { doctorId } = params.data;
+
+    const doctor = await prisma.doctor.findUnique({
+      where: { doctorId },
+      select: { doctorId: true },
+    });
+
+    if (!doctor) {
+      return res.status(404).json({ message: 'Doctor not found' });
+    }
+
+    const parsedBody = availabilitySchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return res.status(400).json({ error: parsedBody.error.flatten() });
+    }
+
+    const { dayOfWeek, startMin, endMin } = parsedBody.data;
+
+    const overlap = await prisma.doctorAvailability.findFirst({
+      where: {
+        doctorId,
+        dayOfWeek,
+        startMin: { lt: endMin },
+        endMin: { gt: startMin },
+      },
+    });
+
+    if (overlap) {
+      return res
+        .status(409)
+        .json({ message: 'Availability overlaps with an existing window' });
+    }
+
+    const created = await prisma.doctorAvailability.create({
+      data: {
+        doctorId,
+        dayOfWeek,
+        startMin,
+        endMin,
+      },
+    });
+
+    res.status(201).json(created);
+  }
+);
 
 export default router;

--- a/tests/doctors.test.ts
+++ b/tests/doctors.test.ts
@@ -29,3 +29,60 @@ describe('Doctor management', () => {
   });
 });
 
+describe('Doctor availability management', () => {
+  let availabilityDoctorId: string;
+
+  beforeAll(async () => {
+    const doctor = await prisma.doctor.create({
+      data: {
+        name: 'Availability Doctor',
+        department: 'General Medicine',
+      },
+    });
+    availabilityDoctorId = doctor.doctorId;
+  });
+
+  afterAll(async () => {
+    await prisma.doctorAvailability.deleteMany({ where: { doctorId: availabilityDoctorId } });
+    await prisma.doctor.deleteMany({ where: { doctorId: availabilityDoctorId } });
+  });
+
+  it('returns default availability when no custom slots exist', async () => {
+    const res = await request(app).get(`/api/doctors/${availabilityDoctorId}/availability`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.doctorId).toBe(availabilityDoctorId);
+    expect(Array.isArray(res.body.availability)).toBe(true);
+    expect(res.body.availability).toHaveLength(0);
+    expect(res.body.defaultAvailability).toEqual([
+      { startMin: 9 * 60, endMin: 17 * 60 },
+    ]);
+  });
+
+  it('creates a custom availability slot and prevents overlaps', async () => {
+    const createRes = await request(app)
+      .post(`/api/doctors/${availabilityDoctorId}/availability`)
+      .send({ dayOfWeek: 1, startMin: 9 * 60, endMin: 12 * 60 });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.doctorId).toBe(availabilityDoctorId);
+    expect(createRes.body.startMin).toBe(9 * 60);
+    expect(createRes.body.endMin).toBe(12 * 60);
+
+    const conflictRes = await request(app)
+      .post(`/api/doctors/${availabilityDoctorId}/availability`)
+      .send({ dayOfWeek: 1, startMin: 11 * 60, endMin: 13 * 60 });
+
+    expect(conflictRes.status).toBe(409);
+
+    const listRes = await request(app).get(`/api/doctors/${availabilityDoctorId}/availability`);
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.availability).toHaveLength(1);
+    expect(listRes.body.availability[0]).toMatchObject({
+      dayOfWeek: 1,
+      startMin: 9 * 60,
+      endMin: 12 * 60,
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- default doctors to 9am-5pm availability windows when no custom slots exist and expose CRUD endpoints for availability
- document availability APIs and expand automated coverage for scheduling defaults and overlaps
- add front-end controls to view and create doctor availability in settings with supporting API helpers

## Testing
- npm test *(fails: missing npm dependencies and restricted registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d023130930832e9494720e3967ff78