### PR TITLE
Add Doctor to User relation back-reference

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ model Doctor {
   blackouts      DoctorBlackout[]
   visits       Visit[]
   observations Observation[]
+  user         User?
 }
 
 model Appointment {


### PR DESCRIPTION
## Summary
- add the missing back-reference from Doctor to User to complete the Prisma relation

## Testing
- npx prisma generate *(fails: npm 403 Forbidden when fetching prisma package)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fb143e44832eb6d7caeff635b046