### PR TITLE
Fix TypeScript role comparison in user update

### DIFF
--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -178,7 +178,7 @@ router.patch('/:id', async (req: Request, res: Response) => {
     } else {
       updates.doctorId = null;
     }
-  } else if (role && role !== 'Doctor') {
+  } else if (role === 'AdminAssistant' || role === 'ITAdmin') {
     updates.doctorId = null;
   }
 


### PR DESCRIPTION
## Summary
- ensure doctor reassignment clearing checks for admin roles without redundant comparisons

## Testing
- npm run build *(fails: `prisma` not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fe594288832e87be80caf89e8e23