### PR TITLE
Fix observation comparison typing

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -649,18 +649,18 @@ function observationHasChanges(
     return true;
   }
 
-  const numericFields: Array<keyof VisitFormObservationValues> = [
+  const numericFields = [
     'bpSystolic',
     'bpDiastolic',
     'heartRate',
     'temperatureC',
     'spo2',
     'bmi',
-  ];
+  ] as const satisfies ReadonlyArray<keyof VisitFormObservationValues & keyof Observation>;
 
   for (const field of numericFields) {
     const nextValue = next[field] ?? null;
-    const latestValue = (latest as Record<string, number | null | undefined>)[field] ?? null;
+    const latestValue = latest[field] ?? null;
     if (nextValue !== latestValue) {
       return true;
     }


### PR DESCRIPTION
## Summary
- ensure observation change detection iterates over a typed list of numeric fields
- access observation numeric values without unsafe record casts to satisfy TypeScript

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68d111cd8ef0832eb11bc97dae1b8ec1