### PR TITLE
feat: add bilingual support with language switch

### DIFF
--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -11,6 +11,7 @@ import {
 } from './icons';
 import { useAuth } from '../context/AuthProvider';
 import { useSettings } from '../context/SettingsProvider';
+import { useTranslation } from '../hooks/useTranslation';
 
 type NavigationKey = 'dashboard' | 'patients' | 'appointments' | 'reports' | 'settings';
 
@@ -38,12 +39,13 @@ interface DashboardLayoutProps {
 }
 
 function DefaultHeaderSearch() {
+  const { t } = useTranslation();
   return (
     <div className="relative w-full md:w-72">
       <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
       <input
         type="search"
-        placeholder="Search patients..."
+        placeholder={t('Search patients...')}
         className="w-full rounded-full border border-gray-200 bg-gray-50 py-2 pl-10 pr-4 text-sm text-gray-700 placeholder:text-gray-400 focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
       />
     </div>
@@ -59,7 +61,8 @@ export default function DashboardLayout({
 }: DashboardLayoutProps) {
   const { user } = useAuth();
   const { appName } = useSettings();
-  const roleLabel = user ? ROLE_LABELS[user.role] ?? user.role : 'Team Member';
+  const { t } = useTranslation();
+  const roleLabel = user ? t(ROLE_LABELS[user.role] ?? 'Team Member') : t('Team Member');
   const navItems = navigation.filter((item) => {
     if (item.key === 'settings') {
       return user?.role === 'ITAdmin';
@@ -69,7 +72,7 @@ export default function DashboardLayout({
   return (
     <div className="flex min-h-screen bg-gray-50">
       <aside className="hidden w-72 flex-col border-r border-gray-200 bg-white px-6 py-8 shadow-sm md:flex">
-        <div className="text-lg font-semibold text-blue-600">{appName || 'EMR System'}</div>
+        <div className="text-lg font-semibold text-blue-600">{appName || t('EMR System')}</div>
         <nav className="mt-8 space-y-1">
           {navItems.map((item) => {
             const Icon = item.icon;
@@ -82,7 +85,7 @@ export default function DashboardLayout({
                 }`}
               >
                 <Icon className="h-5 w-5" />
-                <span>{item.name}</span>
+                <span>{t(item.name)}</span>
               </div>
             );
 
@@ -106,7 +109,7 @@ export default function DashboardLayout({
             <AvatarIcon className="h-6 w-6" />
           </div>
           <div>
-            <div className="text-sm font-medium text-gray-900">{user?.email ?? 'Signed-in user'}</div>
+            <div className="text-sm font-medium text-gray-900">{user?.email ?? t('Signed-in user')}</div>
             <div className="text-xs text-gray-500">{roleLabel}</div>
           </div>
         </div>
@@ -123,7 +126,7 @@ export default function DashboardLayout({
               {headerChildren ?? <DefaultHeaderSearch />}
               <div className="flex items-center gap-3">
                 <div className="hidden flex-col text-right text-xs text-gray-500 sm:flex">
-                  <span className="font-medium text-gray-700">{user?.email ?? 'Signed-in user'}</span>
+                  <span className="font-medium text-gray-700">{user?.email ?? t('Signed-in user')}</span>
                   <span>{roleLabel}</span>
                 </div>
                 <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white">

--- a/client/src/components/LoginCard.tsx
+++ b/client/src/components/LoginCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from '../hooks/useTranslation';
 
 interface LoginCardProps {
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
@@ -15,6 +16,7 @@ export default function LoginCard({
   appName,
   logo,
 }: LoginCardProps) {
+  const { t } = useTranslation();
   return (
     <div className="rounded-2xl bg-white p-8 shadow">
       <div className="mb-6 flex flex-col items-center">
@@ -42,7 +44,7 @@ export default function LoginCard({
           </div>
         )}
         <h1 className="text-2xl font-bold text-gray-900">{appName}</h1>
-        <p className="mt-2 text-sm text-gray-600">Sign in to your account</p>
+        <p className="mt-2 text-sm text-gray-600">{t('Sign in to your account')}</p>
       </div>
 
       <form onSubmit={onSubmit} className="space-y-6">
@@ -51,7 +53,7 @@ export default function LoginCard({
             htmlFor="username"
             className="block text-sm font-medium text-gray-700"
           >
-            Username or Email
+            {t('Username or Email')}
           </label>
           <input
             id="username"
@@ -69,7 +71,7 @@ export default function LoginCard({
             htmlFor="password"
             className="block text-sm font-medium text-gray-700"
           >
-            Password
+            {t('Password')}
           </label>
           <input
             id="password"
@@ -91,10 +93,10 @@ export default function LoginCard({
               onChange={onChange}
               className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
             />
-            <span className="ml-2 text-sm text-gray-700">Remember me</span>
+            <span className="ml-2 text-sm text-gray-700">{t('Remember me')}</span>
           </label>
           <a href="#" className="text-sm text-blue-600 hover:text-blue-500">
-            Forgot your password?
+            {t('Forgot your password?')}
           </a>
         </div>
 
@@ -102,7 +104,7 @@ export default function LoginCard({
           type="submit"
           className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
-          Login
+          {t('Login')}
         </button>
       </form>
     </div>

--- a/client/src/context/LocaleProvider.tsx
+++ b/client/src/context/LocaleProvider.tsx
@@ -1,0 +1,161 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import translationsSource from '../i18n/translations.csv?raw';
+
+export type Language = 'en' | 'my';
+
+type TranslationEntry = {
+  en: string;
+  my: string;
+};
+
+type TranslationMap = Record<string, TranslationEntry>;
+
+type TranslationParams = Record<string, string | number>;
+
+type LocaleContextValue = {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  t: (key: string, params?: TranslationParams) => string;
+  translations: TranslationMap;
+};
+
+function parseCsv(source: string): TranslationMap {
+  const result: TranslationMap = {};
+  const text = source.trim();
+  if (!text) return result;
+
+  const rows: string[][] = [];
+  let current: string[] = [];
+  let field = '';
+  let insideQuotes = false;
+
+  const pushField = () => {
+    current.push(field);
+    field = '';
+  };
+
+  const pushRow = () => {
+    if (current.length > 0) {
+      rows.push(current);
+    }
+    current = [];
+  };
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    const next = text[i + 1];
+
+    if (char === '"') {
+      if (insideQuotes && next === '"') {
+        field += '"';
+        i += 1;
+      } else {
+        insideQuotes = !insideQuotes;
+      }
+    } else if (char === ',' && !insideQuotes) {
+      pushField();
+    } else if ((char === '\n' || char === '\r') && !insideQuotes) {
+      if (char === '\r' && next === '\n') {
+        i += 1;
+      }
+      pushField();
+      pushRow();
+    } else {
+      field += char;
+    }
+  }
+
+  if (field.length > 0 || insideQuotes || current.length > 0) {
+    pushField();
+    pushRow();
+  }
+
+  if (!rows.length) return result;
+
+  const header = rows[0];
+  const keyIndex = header.indexOf('key');
+  const enIndex = header.indexOf('en');
+  const myIndex = header.indexOf('my');
+
+  if (keyIndex === -1 || enIndex === -1 || myIndex === -1) {
+    throw new Error('translations.csv must include key,en,my columns');
+  }
+
+  for (let i = 1; i < rows.length; i += 1) {
+    const row = rows[i];
+    const key = row[keyIndex]?.trim();
+    if (!key) continue;
+    result[key] = {
+      en: row[enIndex]?.trim() ?? key,
+      my: row[myIndex]?.trim() ?? key,
+    };
+  }
+
+  return result;
+}
+
+const LocaleContext = createContext<LocaleContextValue | undefined>(undefined);
+
+const parsedTranslations = parseCsv(translationsSource);
+
+function replaceParams(template: string, params?: TranslationParams): string {
+  if (!params) return template;
+  return template.replace(/\{(.*?)\}/g, (match, token) => {
+    const key = String(token).trim();
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
+      return String(params[key]);
+    }
+    return match;
+  });
+}
+
+export function LocaleProvider({ children }: { children: React.ReactNode }) {
+  const [language, setLanguageState] = useState<Language>(() => {
+    if (typeof window === 'undefined') return 'en';
+    const stored = window.localStorage.getItem('language');
+    return stored === 'my' ? 'my' : 'en';
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('language', language);
+  }, [language]);
+
+  const setLanguage = useCallback((value: Language) => {
+    setLanguageState(value);
+  }, []);
+
+  const t = useCallback(
+    (key: string, params?: TranslationParams) => {
+      const entry = parsedTranslations[key];
+      const template = entry ? entry[language] || entry.en || key : key;
+      return replaceParams(template, params);
+    },
+    [language],
+  );
+
+  const value = useMemo<LocaleContextValue>(
+    () => ({
+      language,
+      setLanguage,
+      t,
+      translations: parsedTranslations,
+    }),
+    [language, setLanguage, t],
+  );
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+  }, [language]);
+
+  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
+}
+
+export function useLocale() {
+  const context = useContext(LocaleContext);
+  if (!context) {
+    throw new Error('useLocale must be used within LocaleProvider');
+  }
+  return context;
+}
+

--- a/client/src/hooks/useTranslation.ts
+++ b/client/src/hooks/useTranslation.ts
@@ -1,0 +1,8 @@
+import { useLocale } from '../context/LocaleProvider';
+
+export function useTranslation() {
+  const { t, language, setLanguage } = useLocale();
+  return { t, language, setLanguage };
+}
+
+export type { Language } from '../context/LocaleProvider';

--- a/client/src/i18n/translations.csv
+++ b/client/src/i18n/translations.csv
@@ -1,0 +1,32 @@
+key,en,my
+Search patients...,Search patients...,လူနာများကို ရှာဖွေပါ...
+EMR System,EMR System,EMR စနစ်
+Dashboard,Dashboard,ဒက်ဘုတ်
+Patients,Patients,လူနာများ
+Appointments,Appointments,ချိန်းစာရင်းများ
+Reports,Reports,အစီရင်ခံစာများ
+Settings,Settings,ချိန်ညှိမှုများ
+Team Member,Team Member,အသင်းဝင်
+Signed-in user,Signed-in user,ဝင်ရောက်ထားသောအသုံးပြုသူ
+Doctor,Doctor,ဆရာဝန်
+Administrative Assistant,Administrative Assistant,စီမံရေးကူညီသူ
+IT Administrator,IT Administrator,IT အုပ်ချုပ်ရေးမှူး
+Sign in to your account,Sign in to your account,သင့်အကောင့်သို့ ဝင်ရောက်ပါ
+Username or Email,Username or Email,အသုံးပြုသူအမည် သို့မဟုတ် အီးမေးလ်
+Password,Password,စကားဝှက်
+Remember me,Remember me,ကျွနော့်ကို မှတ်ထားပါ
+Forgot your password?,Forgot your password?,စကားဝှက်မေ့သွားပါသလား။
+Login,Login,စနစ်သို့ ဝင်ရောက်ပါ
+Login successful,Login successful,ဝင်ရောက်မှု အောင်မြင်ပါသည်
+Application Name,Application Name,အက်ပလီကေးရှင်းအမည်
+Logo,Logo,လိုဂို
+"PNG, JPG or SVG up to 1MB.","PNG, JPG or SVG up to 1MB.",PNG၊ JPG သို့မဟုတ် SVG (၁MB ထိ)
+Interface Language,Interface Language,စနစ်အသုံးပြု ဘာသာစကား
+English,English,အင်္ဂလိပ်
+Choose the language used across the staff experience.,Choose the language used across the staff experience.,ဝန်ထမ်းအသုံးပြုမှုအတွက် ဘာသာစကားကို ရွေးချယ်ပါ။
+Widget {status},Widget {status},ဝီဂျက် {status}
+Enabled,Enabled,ဖွင့်ထားသည်
+Disabled,Disabled,ပိတ်ထားသည်
+Portal name synced as {name},Portal name synced as {name},ပေါ်တယ်အမည်ကို {name} ဟုသတ်မှတ်ထားသည်
+Organization Settings,Organization Settings,အဖွဲ့အစည်း ချိန်ညှိမှုများ
+"Manage branding, staff accounts, and patient-facing tools.","Manage branding, staff accounts, and patient-facing tools.",အသင်းအမှတ်တံဆိပ်၊ ဝန်ထမ်းအကောင့်များနှင့် လူနာဆိုင်ရာ ကိရိယာများကို စီမံပါ။

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,13 +5,16 @@ import App from './App';
 import './styles/index.css';
 import { AuthProvider } from './context/AuthProvider';
 import { SettingsProvider } from './context/SettingsProvider';
+import { LocaleProvider } from './context/LocaleProvider';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <AuthProvider>
         <SettingsProvider>
-          <App />
+          <LocaleProvider>
+            <App />
+          </LocaleProvider>
         </SettingsProvider>
       </AuthProvider>
     </BrowserRouter>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthProvider';
 import LoginCard from '../components/LoginCard';
 import PageLayout from '../components/PageLayout';
 import { useSettings } from '../context/SettingsProvider';
+import { useTranslation } from '../hooks/useTranslation';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -13,6 +14,7 @@ export default function Login() {
   const { login } = useAuth();
   const navigate = useNavigate();
   const { appName, logo } = useSettings();
+  const { t } = useTranslation();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -20,7 +22,7 @@ export default function Login() {
     setSuccess(null);
     try {
       await login(email, password);
-      setSuccess('Login successful');
+      setSuccess(t('Login successful'));
       navigate('/');
     } catch (err: any) {
       setError(err.message);

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
 import DashboardLayout from '../components/DashboardLayout';
 import { AvatarIcon, CheckIcon, PatientsIcon, SettingsIcon } from '../components/icons';
 import { useSettings } from '../context/SettingsProvider';
+import { useTranslation, type Language } from '../hooks/useTranslation';
 import {
   DoctorAvailabilitySlot,
   createDoctorAvailability,
@@ -96,6 +97,7 @@ export default function Settings() {
     widgetEnabled,
     setWidgetEnabled,
   } = useSettings();
+  const { t, language, setLanguage } = useTranslation();
 
   const [name, setName] = useState(appName);
   const [userForm, setUserForm] = useState<{ email: string; password: string; role: Role; doctorId: string }>(
@@ -212,6 +214,10 @@ export default function Settings() {
     }
     return formatTimeRange(9 * 60, 17 * 60);
   }, [defaultAvailability]);
+
+  function handleLanguageChange(event: ChangeEvent<HTMLSelectElement>) {
+    setLanguage(event.target.value as Language);
+  }
 
   function handleLogoChange(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
@@ -376,18 +382,18 @@ export default function Settings() {
             : 'bg-gray-100 text-gray-500'
         }`}
       >
-        Widget {widgetEnabled ? 'Enabled' : 'Disabled'}
+        {t('Widget {status}', { status: widgetEnabled ? t('Enabled') : t('Disabled') })}
       </span>
       <span>
-        Portal name synced as <span className="font-medium text-gray-800">{appName}</span>
+        {t('Portal name synced as {name}', { name: appName })}
       </span>
     </div>
   );
 
   return (
     <DashboardLayout
-      title="Organization Settings"
-      subtitle="Manage branding, staff accounts, and patient-facing tools."
+      title={t('Organization Settings')}
+      subtitle={t('Manage branding, staff accounts, and patient-facing tools.')}
       activeItem="settings"
       headerChildren={headerStatus}
     >
@@ -488,7 +494,7 @@ export default function Settings() {
                 <div className="grid gap-4 md:grid-cols-2">
                   <div>
                     <label className="text-sm font-medium text-gray-700" htmlFor="app-name">
-                      Application Name
+                      {t('Application Name')}
                     </label>
                     <input
                       id="app-name"
@@ -501,7 +507,7 @@ export default function Settings() {
 
                   <div>
                     <label className="text-sm font-medium text-gray-700" htmlFor="logo-upload">
-                      Logo
+                      {t('Logo')}
                     </label>
                     <input
                       id="logo-upload"
@@ -510,7 +516,25 @@ export default function Settings() {
                       onChange={handleLogoChange}
                       className="mt-2 block w-full text-sm text-gray-500 file:mr-4 file:rounded-full file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-blue-600 hover:file:bg-blue-100"
                     />
-                    <p className="mt-1 text-xs text-gray-500">PNG, JPG or SVG up to 1MB.</p>
+                    <p className="mt-1 text-xs text-gray-500">{t('PNG, JPG or SVG up to 1MB.')}</p>
+                  </div>
+
+                  <div>
+                    <label className="text-sm font-medium text-gray-700" htmlFor="language-select">
+                      {t('Interface Language')}
+                    </label>
+                    <select
+                      id="language-select"
+                      value={language}
+                      onChange={handleLanguageChange}
+                      className="mt-2 w-full rounded-xl border border-gray-200 px-4 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    >
+                      <option value="en">{t('English')}</option>
+                      <option value="my">မြန်မာ</option>
+                    </select>
+                    <p className="mt-1 text-xs text-gray-500">
+                      {t('Choose the language used across the staff experience.')}
+                    </p>
                   </div>
                 </div>
 

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare module '*.csv?raw' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- add a locale provider that loads CSV-based translations and exposes a useTranslation hook
- localize shared navigation and login components and add an interface language selector in settings
- seed the project with English and Myanmar labels for the translated interface copy

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68d11b8fe40c832ea5602fb8e50e29a6