### PR TITLE
Add Myanmar translations for dashboard and patient search

### DIFF
--- a/client/src/components/PatientSearch.tsx
+++ b/client/src/components/PatientSearch.tsx
@@ -3,15 +3,17 @@ import { Link } from 'react-router-dom';
 import { searchPatients, type Patient } from '../api/client';
 import DashboardLayout from './DashboardLayout';
 import { PatientsIcon, SearchIcon } from './icons';
+import { useTranslation } from '../hooks/useTranslation';
 
 const quickFilters = [
-  { label: 'Recently Registered', query: '2024' },
-  { label: 'Medicare Coverage', query: 'Medicare' },
-  { label: 'Hypertension', query: 'Hypertension' },
-  { label: 'Diabetes', query: 'Diabetes' },
+  { key: 'recently-registered', label: 'Recently Registered', query: '2024' },
+  { key: 'medicare-coverage', label: 'Medicare Coverage', query: 'Medicare' },
+  { key: 'hypertension', label: 'Hypertension', query: 'Hypertension' },
+  { key: 'diabetes', label: 'Diabetes', query: 'Diabetes' },
 ];
 
 export default function PatientSearch() {
+  const { t } = useTranslation();
   const [query, setQuery] = useState('');
   const [debounced, setDebounced] = useState('');
   const [results, setResults] = useState<Patient[]>([]);
@@ -64,7 +66,7 @@ export default function PatientSearch() {
         <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
         <input
           type="search"
-          placeholder="Search patients by name, ID, or insurance..."
+          placeholder={t('Search patients by name, ID, or insurance...')}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           className="w-full rounded-full border border-gray-200 bg-gray-50 py-2 pl-10 pr-4 text-sm text-gray-700 placeholder:text-gray-400 focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
@@ -74,18 +76,26 @@ export default function PatientSearch() {
         to="/register"
         className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-700"
       >
-        Register Patient
+        {t('Register Patient')}
       </Link>
     </div>
   );
 
   const hasQuery = debounced.length > 0;
   const resultCount = results.length;
+  const recordLabel = resultCount === 1 ? t('record') : t('records');
+  const resultsSummary = hasQuery
+    ? t('Showing {count} matching {recordLabel}.', { count: resultCount, recordLabel })
+    : t('Start typing to explore the patient directory.');
+  const matchesLabel =
+    resultCount === 1
+      ? t('{count} match', { count: resultCount })
+      : t('{count} matches', { count: resultCount });
 
   return (
     <DashboardLayout
-      title="Patient Directory"
-      subtitle="Find and manage patient records across the organization."
+      title={t('Patient Directory')}
+      subtitle={t('Find and manage patient records across the organization.')}
       activeItem="patients"
       headerChildren={headerContent}
     >
@@ -93,16 +103,12 @@ export default function PatientSearch() {
         <section className="rounded-2xl bg-white p-6 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">Search Results</h2>
-              <p className="mt-1 text-sm text-gray-600">
-                {hasQuery
-                  ? `Showing ${resultCount} matching ${resultCount === 1 ? 'record' : 'records'}.`
-                  : 'Start typing to explore the patient directory.'}
-              </p>
+              <h2 className="text-lg font-semibold text-gray-900">{t('Search Results')}</h2>
+              <p className="mt-1 text-sm text-gray-600">{resultsSummary}</p>
             </div>
             {hasQuery && (
               <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-600">
-                {resultCount} match{resultCount === 1 ? '' : 'es'}
+                {matchesLabel}
               </span>
             )}
           </div>
@@ -111,22 +117,22 @@ export default function PatientSearch() {
             {isLoading ? (
               <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
                 <SearchIcon className="h-10 w-10 animate-spin text-blue-500" />
-                <div className="text-sm font-medium text-gray-700">Searching for matching patients...</div>
-                <p className="text-xs text-gray-500">Hang tight while we gather the latest records.</p>
+                <div className="text-sm font-medium text-gray-700">{t('Searching for matching patients...')}</div>
+                <p className="text-xs text-gray-500">{t('Hang tight while we gather the latest records.')}</p>
               </div>
             ) : resultCount > 0 ? (
               <table className="min-w-full divide-y divide-gray-100 text-sm">
                 <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
                   <tr>
-                    <th className="px-6 py-3">Patient</th>
-                    <th className="px-6 py-3">Date of Birth</th>
-                    <th className="px-6 py-3">Insurance</th>
-                    <th className="px-6 py-3 text-right">Actions</th>
+                    <th className="px-6 py-3">{t('Patient')}</th>
+                    <th className="px-6 py-3">{t('Date of Birth')}</th>
+                    <th className="px-6 py-3">{t('Insurance')}</th>
+                    <th className="px-6 py-3 text-right">{t('Actions')}</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-100 bg-white">
                   {results.map((patient) => {
-                    const coverage = patient.insurance?.trim() || 'Self-pay';
+                    const coverage = patient.insurance?.trim() || t('Self-pay');
 
                     return (
                       <tr key={patient.patientId} className="transition hover:bg-blue-50/40">
@@ -147,7 +153,7 @@ export default function PatientSearch() {
                             to={`/patients/${patient.patientId}`}
                             className="inline-flex items-center rounded-full bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-blue-700"
                           >
-                            View Profile
+                            {t('View Profile')}
                           </Link>
                         </td>
                       </tr>
@@ -160,11 +166,11 @@ export default function PatientSearch() {
                 <PatientsIcon className="h-10 w-10 text-gray-300" />
                 <div className="text-sm font-medium text-gray-700">
                   {hasQuery
-                    ? 'No patients match your search just yet.'
-                    : 'Search for patients by name, patient ID, or insurance provider.'}
+                    ? t('No patients match your search just yet.')
+                    : t('Search for patients by name, patient ID, or insurance provider.')}
                 </div>
                 {!hasQuery && (
-                  <p className="text-xs text-gray-500">Try "Jane" or "Medicare" to explore the directory.</p>
+                  <p className="text-xs text-gray-500">{t('Try "Jane" or "Medicare" to explore the directory.')}</p>
                 )}
               </div>
             )}
@@ -173,14 +179,14 @@ export default function PatientSearch() {
 
         <aside className="space-y-6">
           <div className="rounded-2xl bg-white p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-gray-900">Quick Filters</h3>
-            <p className="mt-1 text-sm text-gray-600">Jump into commonly referenced patient segments.</p>
+            <h3 className="text-lg font-semibold text-gray-900">{t('Quick Filters')}</h3>
+            <p className="mt-1 text-sm text-gray-600">{t('Jump into commonly referenced patient segments.')}</p>
             <div className="mt-4 flex flex-wrap gap-2">
               {quickFilters.map((filter) => {
                 const isActive = query.toLowerCase() === filter.query.toLowerCase();
                 return (
                   <button
-                    key={filter.label}
+                    key={filter.key}
                     type="button"
                     onClick={() => setQuery(filter.query)}
                     className={`rounded-full px-4 py-2 text-xs font-medium transition ${
@@ -189,7 +195,7 @@ export default function PatientSearch() {
                         : 'bg-blue-50 text-blue-600 hover:bg-blue-100'
                     }`}
                   >
-                    {filter.label}
+                    {t(filter.label)}
                   </button>
                 );
               })}
@@ -197,15 +203,15 @@ export default function PatientSearch() {
           </div>
 
           <div className="rounded-2xl bg-white p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-gray-900">Need to add someone?</h3>
+            <h3 className="text-lg font-semibold text-gray-900">{t('Need to add someone?')}</h3>
             <p className="mt-2 text-sm text-gray-600">
-              Can&apos;t find the patient you&apos;re looking for? Create a new record in just a few steps.
+              {t("Can't find the patient you're looking for? Create a new record in just a few steps.")}
             </p>
             <Link
               to="/register"
               className="mt-4 inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-700"
             >
-              Register Patient
+              {t('Register Patient')}
             </Link>
           </div>
         </aside>

--- a/client/src/i18n/translations.csv
+++ b/client/src/i18n/translations.csv
@@ -30,3 +30,86 @@ Disabled,Disabled,ပိတ်ထားသည်
 Portal name synced as {name},Portal name synced as {name},ပေါ်တယ်အမည်ကို {name} ဟုသတ်မှတ်ထားသည်
 Organization Settings,Organization Settings,အဖွဲ့အစည်း ချိန်ညှိမှုများ
 "Manage branding, staff accounts, and patient-facing tools.","Manage branding, staff accounts, and patient-facing tools.",အသင်းအမှတ်တံဆိပ်၊ ဝန်ထမ်းအကောင့်များနှင့် လူနာဆိုင်ရာ ကိရိယာများကို စီမံပါ။
+Review lab results for A. Jones,Review lab results for A. Jones,A. Jones ၏ သွေးစမ်းသပ်ရလဒ်များကို ပြန်လည်သုံးသပ်ပါ
+Follow up with Dr. Davis,Follow up with Dr. Davis,ဆရာဝန် Davis နှင့် ဆက်လက် ဆွေးနွေးလုပ်ဆောင်ပါ
+General Checkup,General Checkup,အထွေထွေ စစ်ဆေးမှု
+Medication Review,Medication Review,ဆေးဝါး ပြန်လည်သုံးသပ်ခြင်း
+Team Dashboard,Team Dashboard,အသင်း ဒက်ရှ်ဘုတ်
+Monitor appointments and keep patients informed.,Monitor appointments and keep patients informed.,ချိန်းစာရင်းများကို စောင့်ကြည့်ပြီး လူနာများကို သတင်းပေးထားပါ။
+Track clinic activity and coordinate care.,Track clinic activity and coordinate care.,ဆေးခန်း လှုပ်ရှားမှုများကို စောင့်ကြည့်ပြီး ပြုပြင်စောင့်ရှောက်မှုကို ကိုဩဒိနိတ်လုပ်ဆောင်ပါ။
+Register New Patient,Register New Patient,လူနာအသစ်ကို စာရင်းသွင်းပါ
+Capture demographics and intake information for walk-in patients.,Capture demographics and intake information for walk-in patients.,အလိုလို ဝင်ရောက်လာသော လူနာများအတွက် လူမျိုးရေးနှင့် ဝင်ရောက် အသေးစိတ် အချက်အလက်များကို သိမ်းဆည်းပါ။
+Register Patient,Register Patient,လူနာကို စာရင်းသွင်းပါ
+Search Patient Records,Search Patient Records,လူနာမှတ်တမ်းများကို ရှာဖွေပါ
+"Look up patients to confirm coverage, history, and contact details.","Look up patients to confirm coverage, history, and contact details.",လူနာများ၏ အာမခံ၊ မှတ်တမ်းနှင့် ဆက်သွယ်ရန် အချက်အလက်များကို အတည်ပြုရန် ရှာဖွေပါ။
+Search Patient,Search Patient,လူနာကို ရှာဖွေပါ
+Patients Today,Patients Today,ယနေ့ လူနာများ
+Scheduled visits and walk-ins awaiting triage.,Scheduled visits and walk-ins awaiting triage.,ချိန်းထားပြီး နှင့် စောင့်ဆိုင်းနေသော လည်ပတ်မှုများ။
+New Messages,New Messages,မက်ဆေ့ဂျ် အသစ်များ
+Updates from labs and internal teams.,Updates from labs and internal teams.,လက်တင်များနှင့် အတွင်းရေးအသင်းများထံမှ အပ်ဒိတ်များ။
+Upcoming Appointments,Upcoming Appointments,မကြာမီလာမည့် ချိန်းများ
+View schedule,View schedule,အချိန်ဇယားကို ကြည့်ပါ
+Task Reminders,Task Reminders,တာဝန် သတိပေးချက်များ
+Unable to load queue.,Unable to load queue.,စာရင်းစဉ်ကို တင်မရပါ။
+Unable to load doctors.,Unable to load doctors.,ဆရာဝန်စာရင်းကို တင်မရပါ။
+Unable to load existing visit details.,Unable to load existing visit details.,ရှိပြီးသား လည်ပတ်အသေးစိတ်ကို တင်မရပါ။
+Invited {name} to the consultation room.,Invited {name} to the consultation room.,{name} ကို အကဲဖြတ်ခန်းသို့ ဖိတ်ခေါ်ခဲ့ပါသည်။
+Unable to update appointment status.,Unable to update appointment status.,ချိန်းစာရင်း အခြေအနေကို ပြင်ဆင်မရပါ။
+Select an appointment before saving visit details.,Select an appointment before saving visit details.,လည်ပတ်အသေးစိတ်ကို သိမ်းဆည်းရန်မီ ချိန်းစာရင်းကို ရွေးချယ်ပါ။
+A doctor must be selected for the visit.,A doctor must be selected for the visit.,ဤလည်ပတ်မှုအတွက် ဆရာဝန်တစ်ဦးကို ရွေးချယ်ရမည်။
+Visit details updated.,Visit details updated.,လည်ပတ်အသေးစိတ်ကို ပြင်ဆင်ပြီးပါပြီ။
+Visit saved and appointment completed.,Visit saved and appointment completed.,လည်ပတ်မှုကို သိမ်းပြီး ချိန်းကို ပြီးမြောက်စေခဲ့ပါသည်။
+Unable to save visit details.,Unable to save visit details.,လည်ပတ်အသေးစိတ်ကို သိမ်းဆည်းမရပါ။
+Today's Queue,Today's Queue,ယနေ့ စာရင်းစဉ်
+"Invite your next patient, capture notes, and wrap up the visit.","Invite your next patient, capture notes, and wrap up the visit.",လာမည့် လူနာကို ဖိတ်ခေါ်ပြီး မှတ်ချက်များကို မှတ်တမ်းတင်ကာ လည်ပတ်မှုကို ပြီးမြောက်စေပါ။
+Refresh Queue,Refresh Queue,စာရင်းစဉ်ကို ပြန်စတင်ပါ
+Loading your appointments...,Loading your appointments...,ချိန်းစာရင်းများကို တင်နေပါသည်...
+Upcoming patients,Upcoming patients,မကြာမီလာမည့် လူနာများ
+{count} in queue,{count} in queue,စာရင်းစဉ်တွင် {count} ယောက်
+No patients waiting. Enjoy a short break!,No patients waiting. Enjoy a short break!,စောင့်နေသော လူနာများ မရှိပါ။ ခဏအနားယူပါ။
+Current patient,Current patient,လက်ရှိ လူနာ
+No visit reason recorded.,No visit reason recorded.,လည်ပတ်ရသည့် အကြောင်းရင်း မမှတ်တမ်းတင်ထားပါ။
+Room assignment pending,Room assignment pending,အခန်းခွဲ ထုတ်ပြန်ရန် စောင့်ဆိုင်းဆဲ
+Scheduled time,Scheduled time,ချိန်းချိန်
+Status,Status,အခြေအနေ
+Visit documentation,Visit documentation,လည်ပတ် မှတ်တမ်းရေးရာ
+Update Visit,Update Visit,လည်ပတ်မှုကို အသစ်ပြင်ပါ
+Save Visit & Complete,Save Visit & Complete,လည်ပတ်မှုကို သိမ်းပြီး ပြီးမြောက်စေပါ
+Inviting...,Inviting...,ဖိတ်ခေါ်နေသည်...
+Invite Patient,Invite Patient,လူနာကို ဖိတ်ခေါ်ပါ
+Loading visit form...,Loading visit form...,လည်ပတ် ဖောင်ကို တင်နေပါသည်...
+Select a patient from the queue to begin charting their visit.,Select a patient from the queue to begin charting their visit.,လည်ပတ် မှတ်တမ်းရေးခြင်းစတင်ရန် စာရင်းစဉ်မှ လူနာတစ်ဦးကို ရွေးချယ်ပါ။
+Scheduled,Scheduled,ချိန်းထားပြီး
+Checked-in,Checked-in,ဖိတ်ဆိုင်းပြီး
+In progress,In progress,လုပ်ဆောင်နေသည်
+Completed,Completed,ပြီးမြောက်ခဲ့သည်
+Cancelled,Cancelled,ပယ်ဖျက်ခဲ့သည်
+Recently Registered,Recently Registered,မကြာသေးမီက စာရင်းသွင်းထားသည်
+Medicare Coverage,Medicare Coverage,Medicare အာမခံ
+Hypertension,Hypertension,သွေးတိုးရောဂါ
+Diabetes,Diabetes,ဆီးချိုရောဂါ
+"Search patients by name, ID, or insurance...","Search patients by name, ID, or insurance...",လူနာများကို အမည်၊ ID သို့မဟုတ် အာမခံဖြင့် ရှာဖွေပါ...
+Patient Directory,Patient Directory,လူနာ လမ်းညွှန်စာရင်း
+Find and manage patient records across the organization.,Find and manage patient records across the organization.,အဖွဲ့အစည်းတစ်ရပ်လုံးရှိ လူနာမှတ်တမ်းများကို ရှာဖွေစီမံပါ။
+Search Results,Search Results,ရှာဖွေမှု ရလဒ်များ
+Showing {count} matching {recordLabel}.,Showing {count} matching {recordLabel}.,{count} ခုနှင့် ကိုက်ညီသော {recordLabel} များကို ပြပါသည်။
+Start typing to explore the patient directory.,Start typing to explore the patient directory.,လူနာ လမ်းညွှန်စာရင်းကို ရှာဖွေရန် စာရိုက်ခြင်းစတင်ပါ။
+record,record,မှတ်တမ်း
+records,records,မှတ်တမ်းများ
+{count} match,{count} match,{count} ခု ကိုက်ညီပါသည်
+{count} matches,{count} matches,{count} ခု ကိုက်ညီပါသည်
+Searching for matching patients...,Searching for matching patients...,ကိုက်ညီသော လူနာများကို ရှာဖွေနေသည်...
+Hang tight while we gather the latest records.,Hang tight while we gather the latest records.,အသစ်ဆုံး မှတ်တမ်းများကို စုစည်းနေသဖြင့် ခဏစောင့်ပါ။
+Patient,Patient,လူနာ
+Date of Birth,Date of Birth,မွေးသက္ကရာဇ်
+Insurance,Insurance,အာမခံ
+Actions,Actions,လုပ်ဆောင်ချက်များ
+Self-pay,Self-pay,ကိုယ်တိုင်ပေးချေ
+View Profile,View Profile,ပရိုဖိုင်ကို ကြည့်ပါ
+No patients match your search just yet.,No patients match your search just yet.,သင့်ရှာဖွေမှုနှင့် ကိုက်ညီသော လူနာများ မရှိသေးပါ။
+"Search for patients by name, patient ID, or insurance provider.","Search for patients by name, patient ID, or insurance provider.",လူနာများကို အမည်၊ လူနာ ID သို့မဟုတ် အာမခံပံ့ပိုးသူဖြင့် ရှာဖွေပါ။
+"Try ""Jane"" or ""Medicare"" to explore the directory.","Try ""Jane"" or ""Medicare"" to explore the directory.","လမ်းညွှန်စာရင်းကို ရှာဖွေရန် ""Jane"" သို့မဟုတ် ""Medicare"" ကို စမ်းကြည့်ပါ။"
+Quick Filters,Quick Filters,ကွပ်မျိုး ရွေးချယ်ချက်များ
+Jump into commonly referenced patient segments.,Jump into commonly referenced patient segments.,အများဆုံး ကိုးကားသော လူနာအဖွဲ့အစည်းများသို့ ချက်ချင်း ဝင်ရောက်ပါ။
+Need to add someone?,Need to add someone?,တစ်ယောက် ထပ်ထည့်လိုပါသလား။
+Can't find the patient you're looking for? Create a new record in just a few steps.,Can't find the patient you're looking for? Create a new record in just a few steps.,ရှာဖွေနေသော လူနာကို မတွေ့ဘူးလား။ အဆင့်အနည်းငယ်သာဖြင့် မှတ်တမ်းအသစ်တစ်ခု ဖန်တီးနိုင်ပါသည်။

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -27,6 +27,7 @@ import {
   type VisitFormObservationValues,
   type VisitFormSubmitValues,
 } from '../utils/visitForm';
+import { useTranslation } from '../hooks/useTranslation';
 
 export default function Home() {
   const { user } = useAuth();
@@ -39,10 +40,14 @@ export default function Home() {
 }
 
 function TeamDashboard({ role }: { role?: string }) {
-  const taskReminders = ['Review lab results for A. Jones', 'Follow up with Dr. Davis'];
+  const { t } = useTranslation();
+  const taskReminders = [
+    { key: 'review-labs', label: t('Review lab results for A. Jones') },
+    { key: 'follow-up', label: t('Follow up with Dr. Davis') },
+  ];
   const upcomingAppointments = [
-    { name: 'John Doe', time: '10:00 AM', detail: 'General Checkup' },
-    { name: 'Jane Smith', time: '11:30 AM', detail: 'Medication Review' },
+    { key: 'john-doe', name: 'John Doe', time: '10:00 AM', detail: t('General Checkup') },
+    { key: 'jane-smith', name: 'Jane Smith', time: '11:30 AM', detail: t('Medication Review') },
   ];
 
   const headerSearch = (
@@ -50,7 +55,7 @@ function TeamDashboard({ role }: { role?: string }) {
       <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
       <input
         type="search"
-        placeholder="Search patients..."
+        placeholder={t('Search patients...')}
         className="w-full rounded-full border border-gray-200 bg-gray-50 py-2 pl-10 pr-4 text-sm text-gray-700 placeholder:text-gray-400 focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
       />
     </div>
@@ -58,12 +63,12 @@ function TeamDashboard({ role }: { role?: string }) {
 
   return (
     <DashboardLayout
-      title="Team Dashboard"
+      title={t('Team Dashboard')}
       activeItem="dashboard"
       subtitle={
         role === 'AdminAssistant'
-          ? 'Monitor appointments and keep patients informed.'
-          : 'Track clinic activity and coordinate care.'
+          ? t('Monitor appointments and keep patients informed.')
+          : t('Track clinic activity and coordinate care.')
       }
       headerChildren={headerSearch}
     >
@@ -74,9 +79,9 @@ function TeamDashboard({ role }: { role?: string }) {
               <RegisterIcon className="h-6 w-6" />
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">Register New Patient</h2>
+              <h2 className="text-lg font-semibold text-gray-900">{t('Register New Patient')}</h2>
               <p className="mt-1 text-sm text-gray-600">
-                Capture demographics and intake information for walk-in patients.
+                {t('Capture demographics and intake information for walk-in patients.')}
               </p>
             </div>
           </div>
@@ -85,7 +90,7 @@ function TeamDashboard({ role }: { role?: string }) {
               to="/register"
               className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-700"
             >
-              Register Patient
+              {t('Register Patient')}
             </Link>
           </div>
         </div>
@@ -96,8 +101,10 @@ function TeamDashboard({ role }: { role?: string }) {
               <SearchIcon className="h-6 w-6" />
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">Search Patient Records</h2>
-              <p className="mt-1 text-sm text-gray-600">Look up patients to confirm coverage, history, and contact details.</p>
+              <h2 className="text-lg font-semibold text-gray-900">{t('Search Patient Records')}</h2>
+              <p className="mt-1 text-sm text-gray-600">
+                {t('Look up patients to confirm coverage, history, and contact details.')}
+              </p>
             </div>
           </div>
           <div className="mt-6">
@@ -105,17 +112,17 @@ function TeamDashboard({ role }: { role?: string }) {
               to="/patients"
               className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-700"
             >
-              Search Patient
+              {t('Search Patient')}
             </Link>
           </div>
         </div>
 
         <div className="flex flex-col justify-between rounded-2xl bg-white p-6 shadow-sm">
           <div>
-            <div className="text-sm font-medium text-gray-500">Patients Today</div>
+            <div className="text-sm font-medium text-gray-500">{t('Patients Today')}</div>
             <div className="mt-2 text-4xl font-semibold text-gray-900">25</div>
           </div>
-          <p className="mt-4 text-sm text-gray-600">Scheduled visits and walk-ins awaiting triage.</p>
+          <p className="mt-4 text-sm text-gray-600">{t('Scheduled visits and walk-ins awaiting triage.')}</p>
         </div>
 
         <div className="flex flex-col justify-between rounded-2xl bg-white p-6 shadow-sm">
@@ -124,23 +131,23 @@ function TeamDashboard({ role }: { role?: string }) {
               <MessageIcon className="h-6 w-6" />
             </div>
             <div>
-              <div className="text-sm font-medium text-gray-500">New Messages</div>
+              <div className="text-sm font-medium text-gray-500">{t('New Messages')}</div>
               <div className="mt-2 text-4xl font-semibold text-gray-900">3</div>
-              <p className="mt-2 text-sm text-gray-600">Updates from labs and internal teams.</p>
+              <p className="mt-2 text-sm text-gray-600">{t('Updates from labs and internal teams.')}</p>
             </div>
           </div>
         </div>
 
         <div className="rounded-2xl bg-white p-6 shadow-sm">
           <div className="flex items-center justify-between">
-            <div className="text-lg font-semibold text-gray-900">Upcoming Appointments</div>
+            <div className="text-lg font-semibold text-gray-900">{t('Upcoming Appointments')}</div>
             <Link to="/appointments" className="text-xs font-semibold text-blue-600 hover:underline">
-              View schedule
+              {t('View schedule')}
             </Link>
           </div>
           <ul className="mt-4 space-y-3">
             {upcomingAppointments.map((appointment) => (
-              <li key={appointment.name} className="flex items-center justify-between rounded-xl bg-gray-50 px-4 py-3">
+              <li key={appointment.key} className="flex items-center justify-between rounded-xl bg-gray-50 px-4 py-3">
                 <div>
                   <div className="text-sm font-medium text-gray-900">{appointment.name}</div>
                   <div className="text-xs text-gray-500">{appointment.detail}</div>
@@ -152,14 +159,14 @@ function TeamDashboard({ role }: { role?: string }) {
         </div>
 
         <div className="rounded-2xl bg-white p-6 shadow-sm">
-          <div className="text-lg font-semibold text-gray-900">Task Reminders</div>
+          <div className="text-lg font-semibold text-gray-900">{t('Task Reminders')}</div>
           <ul className="mt-4 space-y-3">
             {taskReminders.map((task) => (
-              <li key={task} className="flex items-center gap-3 rounded-xl bg-gray-50 px-4 py-3">
+              <li key={task.key} className="flex items-center gap-3 rounded-xl bg-gray-50 px-4 py-3">
                 <span className="flex h-6 w-6 items-center justify-center rounded-full bg-green-100 text-green-600">
                   <CheckIcon className="h-4 w-4" />
                 </span>
-                <span className="text-sm text-gray-700">{task}</span>
+                <span className="text-sm text-gray-700">{task.label}</span>
               </li>
             ))}
           </ul>
@@ -181,6 +188,8 @@ function DoctorQueueDashboard() {
   const [doctors, setDoctors] = useState<Doctor[]>([]);
   const [invitingId, setInvitingId] = useState<string | null>(null);
   const [savingVisit, setSavingVisit] = useState(false);
+  const { t } = useTranslation();
+  const statusVisuals = getStatusVisuals(t);
 
   const loadQueue = useCallback(async () => {
     setLoading(true);
@@ -189,12 +198,12 @@ function DoctorQueueDashboard() {
       const response = await getAppointmentQueue();
       setAppointments(response.data);
     } catch (err) {
-      setError(parseErrorMessage(err, 'Unable to load queue.'));
+      setError(parseErrorMessage(err, t('Unable to load queue.')));
       setAppointments([]);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     loadQueue();
@@ -212,7 +221,7 @@ function DoctorQueueDashboard() {
       } catch (err) {
         if (!ignore) {
           console.error(err);
-          setError(parseErrorMessage(err, 'Unable to load doctors.'));
+          setError(parseErrorMessage(err, t('Unable to load doctors.')));
         }
       }
     }
@@ -284,7 +293,7 @@ function DoctorQueueDashboard() {
       } catch (err) {
         if (!ignore) {
           console.error(err);
-          setError(parseErrorMessage(err, 'Unable to load existing visit details.'));
+          setError(parseErrorMessage(err, t('Unable to load existing visit details.')));
         }
       }
     }
@@ -310,10 +319,10 @@ function DoctorQueueDashboard() {
     try {
       await patchStatus(appointment.appointmentId, { status: 'InProgress' });
       await loadQueue();
-      setSuccess(`Invited ${appointment.patient.name} to the consultation room.`);
+      setSuccess(t('Invited {name} to the consultation room.', { name: appointment.patient.name }));
       setSelectedId(appointment.appointmentId);
     } catch (err) {
-      setError(parseErrorMessage(err, 'Unable to update appointment status.'));
+      setError(parseErrorMessage(err, t('Unable to update appointment status.')));
     } finally {
       setInvitingId(null);
     }
@@ -321,12 +330,12 @@ function DoctorQueueDashboard() {
 
   const handleVisitSubmit = async (values: VisitFormSubmitValues) => {
     if (!selected) {
-      setError('Select an appointment before saving visit details.');
+      setError(t('Select an appointment before saving visit details.'));
       return;
     }
 
     if (!values.doctorId) {
-      setError('A doctor must be selected for the visit.');
+      setError(t('A doctor must be selected for the visit.'));
       return;
     }
 
@@ -387,14 +396,14 @@ function DoctorQueueDashboard() {
 
       setSuccess(
         selected.status === 'Completed'
-          ? 'Visit details updated.'
-          : 'Visit saved and appointment completed.',
+          ? t('Visit details updated.')
+          : t('Visit saved and appointment completed.'),
       );
       await loadQueue();
       setSelectedId(selected.appointmentId);
     } catch (err) {
       console.error(err);
-      setError(parseErrorMessage(err, 'Unable to save visit details.'));
+      setError(parseErrorMessage(err, t('Unable to save visit details.')));
     } finally {
       setSavingVisit(false);
     }
@@ -402,16 +411,16 @@ function DoctorQueueDashboard() {
 
   return (
     <DashboardLayout
-      title="Today's Queue"
+      title={t("Today's Queue")}
       activeItem="dashboard"
-      subtitle="Invite your next patient, capture notes, and wrap up the visit."
+      subtitle={t('Invite your next patient, capture notes, and wrap up the visit.')}
       headerChildren={
         <button
           type="button"
           onClick={loadQueue}
           className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
         >
-          Refresh Queue
+          {t('Refresh Queue')}
         </button>
       }
     >
@@ -419,22 +428,22 @@ function DoctorQueueDashboard() {
         <div className="flex justify-center">
           <div className="flex flex-col items-center gap-3 rounded-2xl bg-white p-10 shadow-sm">
             <SearchIcon className="h-10 w-10 animate-spin text-blue-500" />
-            <p className="text-sm font-medium text-gray-600">Loading your appointments...</p>
+            <p className="text-sm font-medium text-gray-600">{t('Loading your appointments...')}</p>
           </div>
         </div>
       ) : (
         <div className="grid gap-6 lg:grid-cols-[2fr_3fr]">
           <section className="rounded-2xl bg-white p-6 shadow-sm">
             <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-gray-900">Upcoming patients</h2>
+              <h2 className="text-lg font-semibold text-gray-900">{t('Upcoming patients')}</h2>
               <span className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-600">
-                {appointments.length} in queue
+                {t('{count} in queue', { count: appointments.length })}
               </span>
             </div>
             <ul className="mt-4 space-y-3">
               {appointments.length === 0 ? (
                 <li className="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-6 text-sm text-gray-500">
-                  No patients waiting. Enjoy a short break!
+                  {t('No patients waiting. Enjoy a short break!')}
                 </li>
               ) : (
                 appointments.map((appointment) => {
@@ -474,28 +483,30 @@ function DoctorQueueDashboard() {
             {selected ? (
               <div className="flex flex-col gap-6">
                 <div>
-                  <div className="text-sm font-medium text-gray-500">Current patient</div>
+                  <div className="text-sm font-medium text-gray-500">{t('Current patient')}</div>
                   <h2 className="mt-1 text-2xl font-semibold text-gray-900">{selected.patient.name}</h2>
                   <p className="mt-1 text-sm text-gray-600">
-                    {selected.reason || 'No visit reason recorded.'} · {selected.location || 'Room assignment pending'}
+                    {(selected.reason && selected.reason.trim()) || t('No visit reason recorded.')}
+                    {' · '}
+                    {(selected.location && selected.location.trim()) || t('Room assignment pending')}
                   </p>
                 </div>
 
                 <dl className="grid gap-4 sm:grid-cols-2">
                   <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
-                    <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">Scheduled time</dt>
+                    <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">{t('Scheduled time')}</dt>
                     <dd className="mt-1 text-sm font-medium text-gray-900">
                       {formatDateDisplay(selected.date)} · {formatTimeRange(selected.startTimeMin, selected.endTimeMin)}
                     </dd>
                   </div>
                   <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
-                    <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">Status</dt>
+                    <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500">{t('Status')}</dt>
                     <dd className="mt-1 text-sm font-medium text-gray-900">{statusVisuals[selected.status].label}</dd>
                   </div>
                 </dl>
 
                 <div className="space-y-3">
-                  <h3 className="text-sm font-medium text-gray-700">Visit documentation</h3>
+                  <h3 className="text-sm font-medium text-gray-700">{t('Visit documentation')}</h3>
                   {visitInitialValues ? (
                     <VisitForm
                       doctors={doctors}
@@ -506,8 +517,8 @@ function DoctorQueueDashboard() {
                       disableVisitDate
                       submitLabel={
                         selected.status === 'Completed'
-                          ? 'Update Visit'
-                          : 'Save Visit & Complete'
+                          ? t('Update Visit')
+                          : t('Save Visit & Complete')
                       }
                       submitDisabled={
                         !(selected.status === 'InProgress' || selected.status === 'Completed')
@@ -526,8 +537,8 @@ function DoctorQueueDashboard() {
                                 }`}
                               >
                                 {invitingId === selected.appointmentId
-                                  ? 'Inviting...'
-                                  : 'Invite Patient'}
+                                  ? t('Inviting...')
+                                  : t('Invite Patient')}
                               </button>
                             )
                           : null
@@ -535,7 +546,7 @@ function DoctorQueueDashboard() {
                     />
                   ) : (
                     <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-6 text-sm text-gray-500">
-                      Loading visit form...
+                      {t('Loading visit form...')}
                     </div>
                   )}
                 </div>
@@ -549,7 +560,7 @@ function DoctorQueueDashboard() {
               </div>
             ) : (
               <div className="flex h-full flex-col items-center justify-center rounded-2xl border border-dashed border-gray-200 bg-gray-50 p-8 text-center text-sm text-gray-500">
-                Select a patient from the queue to begin charting their visit.
+                {t('Select a patient from the queue to begin charting their visit.')}
               </div>
             )}
           </section>
@@ -669,33 +680,39 @@ function observationHasChanges(
   return false;
 }
 
-const statusVisuals: Record<AppointmentStatus, { label: string; chip: string; dot: string }> = {
-  Scheduled: {
-    label: 'Scheduled',
-    chip: 'bg-blue-50 text-blue-600',
-    dot: 'bg-blue-500',
-  },
-  CheckedIn: {
-    label: 'Checked-in',
-    chip: 'bg-amber-50 text-amber-700',
-    dot: 'bg-amber-500',
-  },
-  InProgress: {
-    label: 'In progress',
-    chip: 'bg-purple-50 text-purple-700',
-    dot: 'bg-purple-500',
-  },
-  Completed: {
-    label: 'Completed',
-    chip: 'bg-green-50 text-green-700',
-    dot: 'bg-green-500',
-  },
-  Cancelled: {
-    label: 'Cancelled',
-    chip: 'bg-gray-100 text-gray-500',
-    dot: 'bg-gray-400',
-  },
-};
+type Translate = (key: string, params?: Record<string, string | number>) => string;
+
+function getStatusVisuals(
+  t: Translate,
+): Record<AppointmentStatus, { label: string; chip: string; dot: string }> {
+  return {
+    Scheduled: {
+      label: t('Scheduled'),
+      chip: 'bg-blue-50 text-blue-600',
+      dot: 'bg-blue-500',
+    },
+    CheckedIn: {
+      label: t('Checked-in'),
+      chip: 'bg-amber-50 text-amber-700',
+      dot: 'bg-amber-500',
+    },
+    InProgress: {
+      label: t('In progress'),
+      chip: 'bg-purple-50 text-purple-700',
+      dot: 'bg-purple-500',
+    },
+    Completed: {
+      label: t('Completed'),
+      chip: 'bg-green-50 text-green-700',
+      dot: 'bg-green-500',
+    },
+    Cancelled: {
+      label: t('Cancelled'),
+      chip: 'bg-gray-100 text-gray-500',
+      dot: 'bg-gray-400',
+    },
+  };
+}
 
 function parseErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- hook dashboard views into the translation provider and render Burmese labels for doctor queue widgets
- localize the patient search interface and reuse translated labels for filters, tables, and empty states
- add the necessary Myanmar strings to `client/src/i18n/translations.csv`

## Testing
- npm run lint *(fails: ESLint missing project configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d1263917d4832eb878731ee0bf6790