### PR TITLE
Add reporting summary API and dashboard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import RegisterPatient from './pages/RegisterPatient';
 import AppointmentsPage from './pages/AppointmentsPage';
 import AppointmentForm from './pages/AppointmentForm';
 import AppointmentDetail from './pages/AppointmentDetail';
+import Reports from './pages/Reports';
 import './styles/App.css';
 
 function App() {
@@ -95,6 +96,14 @@ function App() {
         element={
           <RouteGuard>
             <Cohort />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/reports"
+        element={
+          <RouteGuard>
+            <Reports />
           </RouteGuard>
         }
       />

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -101,6 +101,20 @@ export interface CohortResult {
   };
 }
 
+export interface ReportSummary {
+  totals: {
+    patients: number;
+    doctors: number;
+    activePatients: number;
+    visitsLast30Days: number;
+    upcomingAppointments: number;
+  };
+  visitsByDepartment: Array<{ department: string; visitCount: number; patientCount: number }>;
+  topDiagnoses: Array<{ diagnosis: string; count: number }>;
+  labSummaries: Array<{ testName: string; tests: number; averageValue: number | null; lastTestDate: string | null }>;
+  monthlyVisitTrends: Array<{ month: string; visitCount: number }>;
+}
+
 export interface LoginUserInfo {
   userId: string;
   role: Role;
@@ -315,6 +329,10 @@ export async function cohort(params: CohortParams): Promise<CohortResult[]> {
   qs.set('value', String(params.value));
   qs.set('months', String(params.months));
   return fetchJSON(`/insights/cohort?${qs.toString()}`);
+}
+
+export async function getReportSummary(): Promise<ReportSummary> {
+  return fetchJSON('/reports/summary');
 }
 
 export interface UserAccount {

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -26,7 +26,7 @@ const navigation: NavigationItem[] = [
   { key: 'dashboard', name: 'Dashboard', icon: DashboardIcon, to: '/' },
   { key: 'patients', name: 'Patients', icon: PatientsIcon, to: '/patients' },
   { key: 'appointments', name: 'Appointments', icon: CalendarIcon, to: '/appointments' },
-  { key: 'reports', name: 'Reports', icon: ReportsIcon },
+  { key: 'reports', name: 'Reports', icon: ReportsIcon, to: '/reports' },
   { key: 'settings', name: 'Settings', icon: SettingsIcon, to: '/settings' },
 ];
 

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -1,0 +1,281 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+import { getReportSummary, type ReportSummary } from '../api/client';
+import { useTranslation } from '../hooks/useTranslation';
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat().format(value);
+}
+
+function formatDate(value: string | null) {
+  if (!value) return '—';
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return '—';
+  return dt.toLocaleDateString();
+}
+
+function formatMonth(value: string) {
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return value;
+  return dt.toLocaleString(undefined, { month: 'short', year: 'numeric' });
+}
+
+interface MetricCardProps {
+  label: string;
+  value: number;
+  highlight?: boolean;
+}
+
+function MetricCard({ label, value, highlight = false }: MetricCardProps) {
+  return (
+    <div
+      className={`rounded-xl border bg-white p-4 shadow-sm ${
+        highlight ? 'border-blue-200 ring-1 ring-blue-100' : 'border-gray-200'
+      }`}
+    >
+      <p className="text-sm font-medium text-gray-500">{label}</p>
+      <p className="mt-2 text-2xl font-semibold text-gray-900">{formatNumber(value)}</p>
+    </div>
+  );
+}
+
+export default function Reports() {
+  const { t } = useTranslation();
+  const [data, setData] = useState<ReportSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getReportSummary()
+      .then((summary) => {
+        if (!cancelled) {
+          setData(summary);
+        }
+      })
+      .catch((err: any) => {
+        if (!cancelled) {
+          setError(err?.message || t('Unable to load reporting data.'));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
+
+  const metrics = useMemo(() => {
+    if (!data) return [];
+    return [
+      { label: t('Total patients'), value: data.totals.patients, highlight: true },
+      { label: t('Active patients (90d)'), value: data.totals.activePatients },
+      { label: t('Visits in last 30 days'), value: data.totals.visitsLast30Days },
+      { label: t('Upcoming appointments (7d)'), value: data.totals.upcomingAppointments },
+      { label: t('Doctors'), value: data.totals.doctors },
+    ];
+  }, [data, t]);
+
+  return (
+    <DashboardLayout title={t('Reports overview')} subtitle={t('Monitor clinical and operational trends')} activeItem="reports">
+      {loading && <p className="text-sm text-gray-500">{t('Loading report...')}</p>}
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</div>
+      )}
+      {!loading && !error && !data && (
+        <p className="text-sm text-gray-500">{t('No reporting data is available yet.')}</p>
+      )}
+
+      {data && (
+        <div className="space-y-10">
+          <section>
+            <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-5">
+              {metrics.map((metric) => (
+                <MetricCard key={metric.label} {...metric} />
+              ))}
+            </div>
+          </section>
+
+          <section className="grid gap-8 lg:grid-cols-2">
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900">{t('Visits by department (90 days)')}</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                {t('Highlights departments with the highest encounter volume and unique patient counts.')}
+              </p>
+              <div className="mt-4 overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Department')}
+                      </th>
+                      <th scope="col" className="px-4 py-3 text-right font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Visits')}
+                      </th>
+                      <th scope="col" className="px-4 py-3 text-right font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Patients')}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {data.visitsByDepartment.length === 0 && (
+                      <tr>
+                        <td colSpan={3} className="px-4 py-6 text-center text-gray-500">
+                          {t('No visit data available.')}
+                        </td>
+                      </tr>
+                    )}
+                    {data.visitsByDepartment.map((row) => (
+                      <tr key={row.department}>
+                        <td className="px-4 py-2 font-medium text-gray-900">{row.department || t('Unassigned')}</td>
+                        <td className="px-4 py-2 text-right text-gray-700">{formatNumber(row.visitCount)}</td>
+                        <td className="px-4 py-2 text-right text-gray-700">{formatNumber(row.patientCount)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900">{t('Top diagnoses')}</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                {t('Shows the most common diagnoses captured across visits.')}
+              </p>
+              <div className="mt-4 overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Diagnosis')}
+                      </th>
+                      <th scope="col" className="px-4 py-3 text-right font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Occurrences')}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {data.topDiagnoses.length === 0 && (
+                      <tr>
+                        <td colSpan={2} className="px-4 py-6 text-center text-gray-500">
+                          {t('No diagnosis data available.')}
+                        </td>
+                      </tr>
+                    )}
+                    {data.topDiagnoses.map((row) => (
+                      <tr key={row.diagnosis}>
+                        <td className="px-4 py-2 font-medium text-gray-900">{row.diagnosis}</td>
+                        <td className="px-4 py-2 text-right text-gray-700">{formatNumber(row.count)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-8 lg:grid-cols-2">
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900">{t('Lab result summary')}</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                {t('Tracks testing volume, average values and the date of the most recent result for each assay.')}
+              </p>
+              <div className="mt-4 overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Test')}
+                      </th>
+                      <th scope="col" className="px-4 py-3 text-right font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Results recorded')}
+                      </th>
+                      <th scope="col" className="px-4 py-3 text-right font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Average value')}
+                      </th>
+                      <th scope="col" className="px-4 py-3 text-right font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Last result date')}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {data.labSummaries.length === 0 && (
+                      <tr>
+                        <td colSpan={4} className="px-4 py-6 text-center text-gray-500">
+                          {t('No lab data available.')}
+                        </td>
+                      </tr>
+                    )}
+                    {data.labSummaries.map((row) => (
+                      <tr key={row.testName}>
+                        <td className="px-4 py-2 font-medium text-gray-900">{row.testName}</td>
+                        <td className="px-4 py-2 text-right text-gray-700">{formatNumber(row.tests)}</td>
+                        <td className="px-4 py-2 text-right text-gray-700">
+                          {row.averageValue === null ? '—' : row.averageValue.toFixed(1)}
+                        </td>
+                        <td className="px-4 py-2 text-right text-gray-700">{formatDate(row.lastTestDate)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-gray-900">{t('Monthly visit trend')}</h2>
+              <p className="mt-1 text-sm text-gray-500">{t('Rolling six month overview of completed visits.')}</p>
+              <div className="mt-4 overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Month')}
+                      </th>
+                      <th scope="col" className="px-4 py-3 text-right font-medium text-gray-500 uppercase tracking-wide">
+                        {t('Visits')}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {data.monthlyVisitTrends.length === 0 && (
+                      <tr>
+                        <td colSpan={2} className="px-4 py-6 text-center text-gray-500">
+                          {t('No recent visit data available.')}
+                        </td>
+                      </tr>
+                    )}
+                    {data.monthlyVisitTrends.map((row) => (
+                      <tr key={row.month}>
+                        <td className="px-4 py-2 font-medium text-gray-900">{formatMonth(row.month)}</td>
+                        <td className="px-4 py-2 text-right text-gray-700">{formatNumber(row.visitCount)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="mt-6 rounded-lg border border-blue-100 bg-blue-50 p-4">
+                <h3 className="text-sm font-semibold text-blue-800">{t('Need deeper analysis?')}</h3>
+                <p className="mt-1 text-sm text-blue-700">
+                  {t('Run a cohort query to explore patients who match specific lab criteria.')}
+                </p>
+                <Link
+                  to="/cohort"
+                  className="mt-3 inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-500"
+                >
+                  {t('Open cohort explorer')}
+                </Link>
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}
+

--- a/docs/atenxion_agent.md
+++ b/docs/atenxion_agent.md
@@ -14,6 +14,12 @@ curl -H "Authorization: Bearer $TOKEN" \
   "http://localhost:8080/api/insights/cohort?test_name=HbA1c&op=gt&value=8&months=6"
 ```
 
+## Reporting Summary
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/api/reports/summary"
+```
+
 ## Observation Lookup
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \

--- a/src/docs/openapi.ts
+++ b/src/docs/openapi.ts
@@ -272,6 +272,69 @@ const openapi: any = {
         type: 'array',
         items: { $ref: '#/components/schemas/Observation' }
       },
+      ReportTotals: {
+        type: 'object',
+        properties: {
+          patients: { type: 'integer', minimum: 0 },
+          doctors: { type: 'integer', minimum: 0 },
+          activePatients: { type: 'integer', minimum: 0 },
+          visitsLast30Days: { type: 'integer', minimum: 0 },
+          upcomingAppointments: { type: 'integer', minimum: 0 }
+        }
+      },
+      ReportDepartmentBreakdown: {
+        type: 'object',
+        properties: {
+          department: { type: 'string' },
+          visitCount: { type: 'integer', minimum: 0 },
+          patientCount: { type: 'integer', minimum: 0 }
+        }
+      },
+      ReportDiagnosisEntry: {
+        type: 'object',
+        properties: {
+          diagnosis: { type: 'string' },
+          count: { type: 'integer', minimum: 0 }
+        }
+      },
+      ReportLabSummary: {
+        type: 'object',
+        properties: {
+          testName: { type: 'string' },
+          tests: { type: 'integer', minimum: 0 },
+          averageValue: { type: 'number', nullable: true },
+          lastTestDate: { type: 'string', format: 'date-time', nullable: true }
+        }
+      },
+      MonthlyVisitTrend: {
+        type: 'object',
+        properties: {
+          month: { type: 'string', format: 'date-time' },
+          visitCount: { type: 'integer', minimum: 0 }
+        }
+      },
+      ReportSummary: {
+        type: 'object',
+        properties: {
+          totals: { $ref: '#/components/schemas/ReportTotals' },
+          visitsByDepartment: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/ReportDepartmentBreakdown' }
+          },
+          topDiagnoses: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/ReportDiagnosisEntry' }
+          },
+          labSummaries: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/ReportLabSummary' }
+          },
+          monthlyVisitTrends: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/MonthlyVisitTrend' }
+          }
+        }
+      },
       Error: {
         type: 'object',
         required: ['code', 'message'],
@@ -1186,6 +1249,18 @@ addPath('/insights/cohort', 'get', {
     { name: 'months', in: 'query', required: true, schema: { type: 'integer' } }
   ],
   responses: { '200': { description: 'Cohort' } }
+});
+
+addPath('/reports/summary', 'get', {
+  summary: 'Reporting summary',
+  security: [{ bearerAuth: [] }],
+  responses: {
+    '200': {
+      description: 'Aggregated reporting metrics',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/ReportSummary' } } },
+    },
+    '401': { description: 'Unauthorized' },
+  },
 });
 
 addPath('/audit', 'get', {

--- a/src/modules/reports/index.ts
+++ b/src/modules/reports/index.ts
@@ -1,0 +1,137 @@
+import { Router, type Request, type Response } from 'express';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { requireAuth } from '../auth/index.js';
+
+const prisma = new PrismaClient();
+const router = Router();
+
+function startOfToday(): Date {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return now;
+}
+
+function daysAgo(reference: Date, days: number): Date {
+  const copy = new Date(reference);
+  copy.setDate(copy.getDate() - days);
+  return copy;
+}
+
+function daysAhead(reference: Date, days: number): Date {
+  const copy = new Date(reference);
+  copy.setDate(copy.getDate() + days);
+  return copy;
+}
+
+router.get('/summary', requireAuth, async (_req: Request, res: Response) => {
+  const today = startOfToday();
+  const last30Days = daysAgo(today, 30);
+  const last90Days = daysAgo(today, 90);
+  const nextSevenDaysEnd = daysAhead(today, 7);
+  nextSevenDaysEnd.setHours(23, 59, 59, 999);
+
+  const [
+    totalPatients,
+    totalDoctors,
+    visitsLast30Days,
+    upcomingAppointments,
+    activePatients,
+    visitsByDepartmentRows,
+    topDiagnosesRows,
+    labSummariesRows,
+    monthlyVisitTrendRows,
+  ] = await Promise.all([
+    prisma.patient.count(),
+    prisma.doctor.count(),
+    prisma.visit.count({ where: { visitDate: { gte: last30Days } } }),
+    prisma.appointment.count({
+      where: {
+        date: { gte: today, lte: nextSevenDaysEnd },
+        status: { in: ['Scheduled', 'CheckedIn', 'InProgress'] },
+      },
+    }),
+    prisma.visit
+      .findMany({
+        where: { visitDate: { gte: last90Days } },
+        distinct: ['patientId'],
+        select: { patientId: true },
+      })
+      .then((rows) => rows.length),
+    prisma.$queryRaw<Array<{ department: string; visit_count: bigint; patient_count: bigint }>>(
+      Prisma.sql`
+        SELECT department,
+               COUNT(*) AS visit_count,
+               COUNT(DISTINCT "patientId") AS patient_count
+        FROM "Visit"
+        WHERE "visitDate" >= ${last90Days}
+        GROUP BY department
+        ORDER BY visit_count DESC, department ASC
+      `,
+    ),
+    prisma.diagnosis.groupBy({
+      by: ['diagnosis'],
+      _count: { diagnosis: true },
+      orderBy: { _count: { diagnosis: 'desc' } },
+      take: 10,
+    }),
+    prisma.labResult.groupBy({
+      by: ['testName'],
+      where: { testDate: { not: null } },
+      _count: { labId: true },
+      _avg: { resultValue: true },
+      _max: { testDate: true },
+      orderBy: { _count: { labId: 'desc' } },
+      take: 10,
+    }),
+    prisma.$queryRaw<Array<{ month: Date; visit_count: bigint }>>(
+      Prisma.sql`
+        SELECT date_trunc('month', "visitDate") AS month,
+               COUNT(*) AS visit_count
+        FROM "Visit"
+        WHERE "visitDate" >= ${daysAgo(today, 180)}
+        GROUP BY month
+        ORDER BY month ASC
+      `,
+    ),
+  ]);
+
+  const visitsByDepartment = visitsByDepartmentRows.map((row) => ({
+    department: row.department,
+    visitCount: Number(row.visit_count),
+    patientCount: Number(row.patient_count),
+  }));
+
+  const topDiagnoses = topDiagnosesRows.map((row) => ({
+    diagnosis: row.diagnosis,
+    count: row._count.diagnosis,
+  }));
+
+  const labSummaries = labSummariesRows.map((row) => ({
+    testName: row.testName,
+    tests: row._count.labId,
+    averageValue: row._avg.resultValue ?? null,
+    lastTestDate: row._max.testDate ? row._max.testDate.toISOString() : null,
+  }));
+
+  const monthlyVisitTrends = monthlyVisitTrendRows.map((row) => ({
+    month: row.month.toISOString(),
+    visitCount: Number(row.visit_count),
+  }));
+
+  res.json({
+    totals: {
+      patients: totalPatients,
+      doctors: totalDoctors,
+      activePatients,
+      visitsLast30Days,
+      upcomingAppointments,
+    },
+    visitsByDepartment,
+    topDiagnoses,
+    labSummaries,
+    monthlyVisitTrends,
+  });
+});
+
+export default router;
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { docsRouter } from './docs/openapi.js';
 import authRouter from './modules/auth/index.js';
 import appointmentsRouter from './routes/appointments.js';
 import usersRouter from './modules/users/index.js';
+import reportsRouter from './modules/reports/index.js';
 
 export const apiRouter = Router();
 
@@ -31,6 +32,7 @@ apiRouter.use('/audit', auditRouter);
 apiRouter.use('/auth', authRouter);
 apiRouter.use('/appointments', appointmentsRouter);
 apiRouter.use('/users', usersRouter);
+apiRouter.use('/reports', reportsRouter);
 apiRouter.use(docsRouter);
 
 export default apiRouter;

--- a/tests/reports.test.ts
+++ b/tests/reports.test.ts
@@ -1,0 +1,162 @@
+import request from 'supertest';
+import { PrismaClient } from '@prisma/client';
+
+import { app } from '../src/index';
+
+const prisma = new PrismaClient();
+
+function buildToken({
+  userId,
+  role,
+  email,
+  doctorId = null,
+}: {
+  userId: string;
+  role: string;
+  email: string;
+  doctorId?: string | null;
+}) {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: userId,
+      role,
+      email,
+      doctorId,
+    }),
+  ).toString('base64url');
+  return `${header}.${payload}.`;
+}
+
+describe('GET /api/reports/summary', () => {
+  const uniqueDiagnosis = 'Neuro reporting case';
+  const uniqueDepartment = 'Neuro Analytics';
+  const uniqueLab = 'Neuro Panel';
+  let authHeader: string;
+  let patientId: string;
+  let doctorId: string;
+
+  beforeAll(async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: 'reports-user@example.com',
+        passwordHash: 'hash',
+        role: 'ITAdmin',
+        status: 'active',
+      },
+    });
+
+    authHeader = `Bearer ${buildToken({
+      userId: user.userId,
+      role: user.role,
+      email: user.email,
+      doctorId: null,
+    })}`;
+
+    const doctor = await prisma.doctor.create({
+      data: {
+        name: 'Reporting Doctor',
+        department: uniqueDepartment,
+      },
+    });
+    doctorId = doctor.doctorId;
+
+    const patient = await prisma.patient.create({
+      data: {
+        name: 'Reporting Patient',
+        dob: new Date('1990-01-01'),
+        gender: 'F',
+        insurance: 'Aetna',
+      },
+    });
+    patientId = patient.patientId;
+
+    const recentVisit = await prisma.visit.create({
+      data: {
+        patientId,
+        doctorId,
+        visitDate: new Date(),
+        department: uniqueDepartment,
+        reason: 'reporting follow up',
+      },
+    });
+
+    const historicalVisitDate = new Date();
+    historicalVisitDate.setDate(historicalVisitDate.getDate() - 120);
+    await prisma.visit.create({
+      data: {
+        patientId,
+        doctorId,
+        visitDate: historicalVisitDate,
+        department: 'Legacy Care',
+        reason: 'old history',
+      },
+    });
+
+    await prisma.diagnosis.create({
+      data: { visitId: recentVisit.visitId, diagnosis: uniqueDiagnosis },
+    });
+
+    await prisma.labResult.create({
+      data: {
+        visitId: recentVisit.visitId,
+        testName: uniqueLab,
+        resultValue: 4.2,
+        unit: 'mg/dL',
+        testDate: new Date(),
+      },
+    });
+
+    const upcoming = new Date();
+    upcoming.setDate(upcoming.getDate() + 3);
+    await prisma.appointment.create({
+      data: {
+        patientId,
+        doctorId,
+        department: uniqueDepartment,
+        date: upcoming,
+        startTimeMin: 9 * 60,
+        endTimeMin: 9 * 60 + 30,
+        status: 'Scheduled',
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.appointment.deleteMany({ where: { doctorId } });
+    await prisma.labResult.deleteMany({ where: { testName: uniqueLab } });
+    await prisma.diagnosis.deleteMany({ where: { diagnosis: uniqueDiagnosis } });
+    await prisma.visit.deleteMany({ where: { patientId } });
+    await prisma.patient.deleteMany({ where: { patientId } });
+    await prisma.doctor.deleteMany({ where: { doctorId } });
+    await prisma.user.deleteMany({ where: { email: 'reports-user@example.com' } });
+    await prisma.$disconnect();
+  });
+
+  it('returns aggregated operational data', async () => {
+    const res = await request(app).get('/api/reports/summary').set('Authorization', authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.totals).toBeDefined();
+    expect(res.body.totals.patients).toBeGreaterThanOrEqual(1);
+    expect(res.body.totals.visitsLast30Days).toBeGreaterThanOrEqual(1);
+    expect(res.body.totals.upcomingAppointments).toBeGreaterThanOrEqual(1);
+
+    const departmentRow = res.body.visitsByDepartment.find((row: any) => row.department === uniqueDepartment);
+    expect(departmentRow).toBeDefined();
+    expect(departmentRow.visitCount).toBeGreaterThanOrEqual(1);
+    expect(departmentRow.patientCount).toBeGreaterThanOrEqual(1);
+
+    const diagnosisRow = res.body.topDiagnoses.find((row: any) => row.diagnosis === uniqueDiagnosis);
+    expect(diagnosisRow).toBeDefined();
+    expect(diagnosisRow.count).toBeGreaterThanOrEqual(1);
+
+    const labRow = res.body.labSummaries.find((row: any) => row.testName === uniqueLab);
+    expect(labRow).toBeDefined();
+    expect(labRow.tests).toBeGreaterThanOrEqual(1);
+    expect(typeof labRow.lastTestDate).toBe('string');
+
+    expect(Array.isArray(res.body.monthlyVisitTrends)).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a reporting summary endpoint that aggregates patient, visit, diagnosis, lab, and appointment metrics with recent trends
- surface a Reports dashboard page in the client to visualize the metrics and link to the cohort explorer
- document the reporting contract in the OpenAPI description and agent docs, and cover the endpoint with an integration test

## Testing
- `npm test -- --runTestsByPath tests/reports.test.ts` *(fails: Jest not installed because npm install is blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d16c9744e8832e910e7b71ddfe19ee