### PR TITLE
Restyle header layout for updated controls

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import LogoutButton from './LogoutButton';
 import { useSettings } from '../context/SettingsProvider';
 import { useAuth } from '../context/AuthProvider';
+import { AvatarIcon } from './icons';
 
 const ROLE_DISPLAY: Record<string, string> = {
   Doctor: 'Doctor',
@@ -14,31 +15,41 @@ export default function Header() {
   const { accessToken, user } = useAuth();
   const showSettings = user?.role === 'ITAdmin';
   const roleLabel = user ? ROLE_DISPLAY[user.role] ?? user.role : null;
+  const displayName = appName || 'EMR System';
   return (
-    <header className="flex items-center justify-between bg-gray-600 px-4 py-4 text-white">
-      <div className="flex items-center space-x-4">
-        {logo && (
-          <Link to="/">
-            <img src={logo} alt="logo" className="h-16 w-auto rounded" />
-          </Link>
-        )}
-        <span className="text-xl font-semibold">{appName}</span>
-      </div>
-      <div className="flex items-center space-x-4">
-        {roleLabel && (
-          <div className="hidden text-right text-xs text-white/80 sm:flex sm:flex-col">
-            <span className="font-medium text-white">{user?.email}</span>
-            <span>{roleLabel}</span>
+    <header className="border-b border-gray-200 px-6 py-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex flex-col items-start gap-2">
+          {logo ? (
+            <Link to="/" className="flex items-center gap-3 text-gray-900">
+              <img src={logo} alt="logo" className="h-12 w-auto rounded" />
+              <span className="text-2xl font-semibold">{displayName}</span>
+            </Link>
+          ) : (
+            <span className="text-2xl font-semibold text-gray-900">{displayName}</span>
+          )}
+        </div>
+        <div className="flex items-start gap-4">
+          {roleLabel && (
+            <div className="hidden text-right text-xs text-gray-500 sm:flex sm:flex-col">
+              <span className="font-medium text-gray-700">{user?.email}</span>
+              <span>{roleLabel}</span>
+            </div>
+          )}
+          <div className="flex flex-col items-center gap-2">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white">
+              <AvatarIcon className="h-6 w-6" />
+            </div>
+            {showSettings && (
+              <Link to="/settings" className="text-sm font-medium text-blue-600 hover:underline">
+                Settings
+              </Link>
+            )}
+            {accessToken && (
+              <LogoutButton className="text-sm font-medium text-red-600 hover:underline" />
+            )}
           </div>
-        )}
-        {showSettings && (
-          <Link to="/settings" className="text-sm hover:underline">
-            Settings
-          </Link>
-        )}
-        {accessToken && (
-          <LogoutButton className="rounded bg-white/20 px-3 py-1 text-sm text-white hover:bg-white/30" />
-        )}
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- remove the solid gray header bar in favour of a lighter bordered container
- place the configurable logo next to the EMR title and add an avatar badge with stacked actions
- move the settings link and logout button under the avatar icon to match the requested layout

## Testing
- npm run build --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68d25460b210832ea170df796805356c