### PR TITLE
Improve mobile responsiveness across layout

### DIFF
--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -1,9 +1,11 @@
-import type { ComponentType, ReactNode, SVGProps } from 'react';
+import { useState, type ComponentType, type ReactNode, type SVGProps } from 'react';
 import { Link } from 'react-router-dom';
 import {
   AvatarIcon,
   CalendarIcon,
+  CloseIcon,
   DashboardIcon,
+  MenuIcon,
   PatientsIcon,
   ReportsIcon,
   SearchIcon,
@@ -72,69 +74,144 @@ export default function DashboardLayout({
   });
   const displayName = appName || t('EMR System');
   const showSettings = user?.role === 'ITAdmin';
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+  const userEmail = user?.email ?? t('Signed-in user');
+
+  function NavigationLinks({ onNavigate }: { onNavigate?: () => void }) {
+    return (
+      <>
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          const isActive = item.key === activeItem;
+          const content = (
+            <div
+              className={`flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition ${
+                isActive ? 'bg-blue-50 text-blue-600' : 'text-gray-600 hover:bg-gray-100'
+              }`}
+            >
+              <Icon className="h-5 w-5" />
+              <span>{t(item.name)}</span>
+            </div>
+          );
+
+          if (item.to) {
+            return (
+              <Link
+                key={item.key}
+                to={item.to}
+                className="block"
+                aria-current={isActive ? 'page' : undefined}
+                onClick={() => onNavigate?.()}
+              >
+                {content}
+              </Link>
+            );
+          }
+
+          return (
+            <button
+              key={item.key}
+              type="button"
+              className="w-full text-left"
+              onClick={() => onNavigate?.()}
+            >
+              {content}
+            </button>
+          );
+        })}
+      </>
+    );
+  }
+
   return (
     <div className="flex min-h-screen bg-gray-50">
       <aside className="hidden w-72 flex-col border-r border-gray-200 bg-white px-6 py-8 shadow-sm md:flex">
-        <div className="text-lg font-semibold text-blue-600">{appName || t('EMR System')}</div>
+        <div className="text-lg font-semibold text-blue-600">{displayName}</div>
         <nav className="mt-8 space-y-1">
-          {navItems.map((item) => {
-            const Icon = item.icon;
-            const content = (
-              <div
-                className={`flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition ${
-                  item.key === activeItem
-                    ? 'bg-blue-50 text-blue-600'
-                    : 'text-gray-600 hover:bg-gray-100'
-                }`}
-              >
-                <Icon className="h-5 w-5" />
-                <span>{t(item.name)}</span>
-              </div>
-            );
-
-            if (item.to) {
-              return (
-                <Link key={item.key} to={item.to} className="block" aria-current={item.key === activeItem ? 'page' : undefined}>
-                  {content}
-                </Link>
-              );
-            }
-
-            return (
-              <button key={item.key} type="button" className="w-full text-left">
-                {content}
-              </button>
-            );
-          })}
+          <NavigationLinks />
         </nav>
         <div className="mt-auto flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-50 text-blue-600">
             <AvatarIcon className="h-6 w-6" />
           </div>
           <div>
-            <div className="text-sm font-medium text-gray-900">{user?.email ?? t('Signed-in user')}</div>
+            <div className="text-sm font-medium text-gray-900">{userEmail}</div>
             <div className="text-xs text-gray-500">{roleLabel}</div>
           </div>
         </div>
       </aside>
 
+      {isMobileNavOpen && (
+        <div className="fixed inset-0 z-40 flex md:hidden" role="dialog" aria-modal="true">
+          <button
+            type="button"
+            className="absolute inset-0 bg-gray-900/40"
+            aria-label={t('Close navigation')}
+            onClick={() => setIsMobileNavOpen(false)}
+          />
+          <div className="relative ml-auto flex h-full w-72 max-w-full flex-col bg-white px-6 py-6 shadow-xl">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-lg font-semibold text-blue-600">{displayName}</span>
+              <button
+                type="button"
+                onClick={() => setIsMobileNavOpen(false)}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 text-gray-600 hover:bg-gray-100"
+                aria-label={t('Close navigation')}
+              >
+                <CloseIcon className="h-5 w-5" />
+              </button>
+            </div>
+            <nav className="mt-6 space-y-1">
+              <NavigationLinks onNavigate={() => setIsMobileNavOpen(false)} />
+            </nav>
+            <div className="mt-auto space-y-4">
+              <div className="flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-50 text-blue-600">
+                  <AvatarIcon className="h-6 w-6" />
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-gray-900">{userEmail}</div>
+                  <div className="text-xs text-gray-500">{roleLabel}</div>
+                </div>
+              </div>
+              {accessToken && (
+                <div onClick={() => setIsMobileNavOpen(false)}>
+                  <LogoutButton className="w-full rounded-full bg-red-50 px-4 py-2 text-sm font-semibold text-red-600 transition hover:bg-red-100" />
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="flex flex-1 flex-col">
         <header className="border-b border-gray-200 bg-white">
-          <div className="flex flex-col gap-6 px-6 py-6">
+          <div className="flex flex-col gap-6 px-4 py-4 sm:px-6 sm:py-6">
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <Link to="/" className="flex items-center gap-3 text-gray-900">
-                {logo ? (
-                  <img src={logo} alt={`${displayName} logo`} className="h-10 w-auto rounded" />
-                ) : (
-                  <span className="text-xl font-semibold">{displayName}</span>
-                )}
-                {logo && <span className="text-xl font-semibold">{displayName}</span>}
-              </Link>
-              <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-4">
+              <div className="flex items-center justify-between gap-3 md:justify-start">
+                <Link to="/" className="flex items-center gap-3 text-gray-900">
+                  {logo ? (
+                    <img src={logo} alt={`${displayName} logo`} className="h-10 w-auto rounded" />
+                  ) : (
+                    <span className="text-xl font-semibold">{displayName}</span>
+                  )}
+                  {logo && <span className="text-xl font-semibold">{displayName}</span>}
+                </Link>
+                <button
+                  type="button"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 text-gray-600 hover:bg-gray-100 md:hidden"
+                  onClick={() => setIsMobileNavOpen(true)}
+                  aria-label={t('Open navigation')}
+                  aria-expanded={isMobileNavOpen}
+                >
+                  <MenuIcon className="h-5 w-5" />
+                </button>
+              </div>
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-end md:gap-4">
                 {headerChildren ?? <DefaultHeaderSearch />}
                 <div className="flex flex-wrap items-center justify-end gap-3">
                   <div className="hidden flex-col text-right text-xs text-gray-500 sm:flex">
-                    <span className="font-medium text-gray-700">{user?.email ?? t('Signed-in user')}</span>
+                    <span className="font-medium text-gray-700">{userEmail}</span>
                     <span>{roleLabel}</span>
                   </div>
                   {showSettings && (
@@ -158,7 +235,7 @@ export default function DashboardLayout({
           </div>
         </header>
 
-        <main className="flex-1 px-6 py-8">{children}</main>
+        <main className="flex-1 px-4 py-6 sm:px-6 sm:py-8">{children}</main>
       </div>
     </div>
   );

--- a/client/src/components/LoginCard.tsx
+++ b/client/src/components/LoginCard.tsx
@@ -18,7 +18,7 @@ export default function LoginCard({
 }: LoginCardProps) {
   const { t } = useTranslation();
   return (
-    <div className="rounded-2xl bg-white p-8 shadow">
+    <div className="rounded-2xl bg-white p-6 shadow sm:p-8">
       <div className="mb-6 flex flex-col items-center">
         {logo ? (
           <img
@@ -84,8 +84,8 @@ export default function LoginCard({
           />
         </div>
 
-        <div className="flex items-center justify-between">
-          <label htmlFor="remember" className="flex items-center">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <label htmlFor="remember" className="flex items-center text-sm text-gray-700">
             <input
               id="remember"
               name="remember"
@@ -93,9 +93,9 @@ export default function LoginCard({
               onChange={onChange}
               className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
             />
-            <span className="ml-2 text-sm text-gray-700">{t('Remember me')}</span>
+            <span className="ml-2">{t('Remember me')}</span>
           </label>
-          <a href="#" className="text-sm text-blue-600 hover:text-blue-500">
+          <a href="#" className="text-sm text-blue-600 hover:text-blue-500 sm:self-end">
             {t('Forgot your password?')}
           </a>
         </div>

--- a/client/src/components/PageLayout.tsx
+++ b/client/src/components/PageLayout.tsx
@@ -8,7 +8,7 @@ interface PageLayoutProps {
 export default function PageLayout({ children, maxWidth = 'max-w-2xl' }: PageLayoutProps) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
-      <div className={`w-full ${maxWidth} rounded-2xl bg-white p-8 shadow`}>{children}</div>
+      <div className={`w-full ${maxWidth} rounded-2xl bg-white p-6 shadow sm:p-8`}>{children}</div>
     </div>
   );
 }

--- a/client/src/components/PatientSearch.tsx
+++ b/client/src/components/PatientSearch.tsx
@@ -113,7 +113,7 @@ export default function PatientSearch() {
             )}
           </div>
 
-          <div className="mt-6 overflow-hidden rounded-xl border border-gray-100">
+          <div className="mt-6 rounded-xl border border-gray-100">
             {isLoading ? (
               <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
                 <SearchIcon className="h-10 w-10 animate-spin text-blue-500" />
@@ -121,46 +121,48 @@ export default function PatientSearch() {
                 <p className="text-xs text-gray-500">{t('Hang tight while we gather the latest records.')}</p>
               </div>
             ) : resultCount > 0 ? (
-              <table className="min-w-full divide-y divide-gray-100 text-sm">
-                <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
-                  <tr>
-                    <th className="px-6 py-3">{t('Patient')}</th>
-                    <th className="px-6 py-3">{t('Date of Birth')}</th>
-                    <th className="px-6 py-3">{t('Insurance')}</th>
-                    <th className="px-6 py-3 text-right">{t('Actions')}</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-100 bg-white">
-                  {results.map((patient) => {
-                    const coverage = patient.insurance?.trim() || t('Self-pay');
+              <div className="w-full overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-100 text-sm">
+                  <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    <tr>
+                      <th className="px-6 py-3">{t('Patient')}</th>
+                      <th className="px-6 py-3">{t('Date of Birth')}</th>
+                      <th className="px-6 py-3">{t('Insurance')}</th>
+                      <th className="px-6 py-3 text-right">{t('Actions')}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 bg-white">
+                    {results.map((patient) => {
+                      const coverage = patient.insurance?.trim() || t('Self-pay');
 
-                    return (
-                      <tr key={patient.patientId} className="transition hover:bg-blue-50/40">
-                        <td className="px-6 py-4">
-                          <div className="font-medium text-gray-900">{patient.name}</div>
-                          <div className="text-xs text-gray-500">ID: {patient.patientId}</div>
-                        </td>
-                        <td className="px-6 py-4 text-gray-700">
-                          {new Date(patient.dob).toLocaleDateString()}
-                        </td>
-                        <td className="px-6 py-4">
-                          <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">
-                            {coverage}
-                          </span>
-                        </td>
-                        <td className="px-6 py-4 text-right">
-                          <Link
-                            to={`/patients/${patient.patientId}`}
-                            className="inline-flex items-center rounded-full bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-blue-700"
-                          >
-                            {t('View Profile')}
-                          </Link>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+                      return (
+                        <tr key={patient.patientId} className="transition hover:bg-blue-50/40">
+                          <td className="px-6 py-4">
+                            <div className="font-medium text-gray-900">{patient.name}</div>
+                            <div className="text-xs text-gray-500">ID: {patient.patientId}</div>
+                          </td>
+                          <td className="px-6 py-4 text-gray-700">
+                            {new Date(patient.dob).toLocaleDateString()}
+                          </td>
+                          <td className="px-6 py-4">
+                            <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">
+                              {coverage}
+                            </span>
+                          </td>
+                          <td className="px-6 py-4 text-right">
+                            <Link
+                              to={`/patients/${patient.patientId}`}
+                              className="inline-flex items-center rounded-full bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-blue-700"
+                            >
+                              {t('View Profile')}
+                            </Link>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
             ) : (
               <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
                 <PatientsIcon className="h-10 w-10 text-gray-300" />

--- a/client/src/components/icons.tsx
+++ b/client/src/components/icons.tsx
@@ -150,3 +150,19 @@ export function AISummaryIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+export function MenuIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 6.75h15M4.5 12h15M4.5 17.25h15" />
+    </svg>
+  );
+}
+
+export function CloseIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M6 18L18 6" />
+    </svg>
+  );
+}
+

--- a/client/src/styles/App.css
+++ b/client/src/styles/App.css
@@ -1,3 +1,3 @@
 #root {
-  padding: 1rem;
+  min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- add a mobile drawer navigation experience and responsive header spacing to the dashboard layout
- tighten login and shared page padding for smaller screens, including new menu/close icons and root height adjustments
- allow patient directory tables to scroll horizontally on narrow viewports without breaking the layout

## Testing
- npm run build (client)


------
https://chatgpt.com/codex/tasks/task_e_68d353e2ff08832ea2703af0574ca17d