### PR TITLE
feat: add pharmacy module MVP

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,8 @@ import AppointmentsPage from './pages/AppointmentsPage';
 import AppointmentForm from './pages/AppointmentForm';
 import AppointmentDetail from './pages/AppointmentDetail';
 import Reports from './pages/Reports';
+import PharmacyQueue from './pages/PharmacyQueue';
+import DispenseDetail from './pages/DispenseDetail';
 import './styles/App.css';
 
 function App() {
@@ -104,6 +106,22 @@ function App() {
         element={
           <RouteGuard>
             <Reports />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/pharmacy/queue"
+        element={
+          <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech', 'ITAdmin']}>
+            <PharmacyQueue />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/pharmacy/dispense/:prescriptionId"
+        element={
+          <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech']}>
+            <DispenseDetail />
           </RouteGuard>
         }
       />

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -1,6 +1,12 @@
 import { fetchJSON } from './http';
 
-export type Role = 'Doctor' | 'AdminAssistant' | 'ITAdmin';
+export type Role =
+  | 'Doctor'
+  | 'AdminAssistant'
+  | 'ITAdmin'
+  | 'Pharmacist'
+  | 'PharmacyTech'
+  | 'InventoryManager';
 
 export interface Patient {
   patientId: string;

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -7,6 +7,7 @@ import {
   DashboardIcon,
   MenuIcon,
   PatientsIcon,
+  PharmacyIcon,
   ReportsIcon,
   SearchIcon,
   SettingsIcon,
@@ -16,7 +17,13 @@ import { useAuth } from '../context/AuthProvider';
 import { useSettings } from '../context/SettingsProvider';
 import { useTranslation } from '../hooks/useTranslation';
 
-type NavigationKey = 'dashboard' | 'patients' | 'appointments' | 'reports' | 'settings';
+type NavigationKey =
+  | 'dashboard'
+  | 'patients'
+  | 'appointments'
+  | 'pharmacy'
+  | 'reports'
+  | 'settings';
 
 type NavigationItem = {
   key: NavigationKey;
@@ -29,6 +36,7 @@ const navigation: NavigationItem[] = [
   { key: 'dashboard', name: 'Dashboard', icon: DashboardIcon, to: '/' },
   { key: 'patients', name: 'Patients', icon: PatientsIcon, to: '/patients' },
   { key: 'appointments', name: 'Appointments', icon: CalendarIcon, to: '/appointments' },
+  { key: 'pharmacy', name: 'Pharmacy', icon: PharmacyIcon, to: '/pharmacy/queue' },
   { key: 'reports', name: 'Reports', icon: ReportsIcon, to: '/reports' },
   { key: 'settings', name: 'Settings', icon: SettingsIcon, to: '/settings' },
 ];
@@ -69,6 +77,9 @@ export default function DashboardLayout({
   const navItems = navigation.filter((item) => {
     if (item.key === 'settings') {
       return user?.role === 'ITAdmin';
+    }
+    if (item.key === 'pharmacy') {
+      return user && ['Pharmacist', 'PharmacyTech', 'ITAdmin'].includes(user.role);
     }
     return true;
   });
@@ -247,4 +258,7 @@ const ROLE_LABELS: Record<string, string> = {
   Doctor: 'Doctor',
   AdminAssistant: 'Administrative Assistant',
   ITAdmin: 'IT Administrator',
+  Pharmacist: 'Pharmacist',
+  PharmacyTech: 'Pharmacy Technician',
+  InventoryManager: 'Inventory Manager',
 };

--- a/client/src/components/PrescribeDrawer.tsx
+++ b/client/src/components/PrescribeDrawer.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+import { fetchJSON } from '../api/http';
+
+interface PrescribeDrawerProps {
+  visitId: string;
+  patientId: string;
+}
+
+interface DraftItem {
+  drugId: string;
+  dose: string;
+  route: string;
+  frequency: string;
+  durationDays: number;
+  quantityPrescribed: number;
+}
+
+const DEFAULT_ITEM: DraftItem = {
+  drugId: '',
+  dose: '',
+  route: 'PO',
+  frequency: 'TID',
+  durationDays: 5,
+  quantityPrescribed: 10,
+};
+
+export default function PrescribeDrawer({ visitId, patientId }: PrescribeDrawerProps) {
+  const [items, setItems] = useState<DraftItem[]>([{ ...DEFAULT_ITEM }]);
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  function updateItem(index: number, changes: Partial<DraftItem>) {
+    setItems((current) =>
+      current.map((item, i) => (i === index ? { ...item, ...changes } : item)),
+    );
+  }
+
+  function addItem() {
+    setItems((current) => [...current, { ...DEFAULT_ITEM }]);
+  }
+
+  function removeItem(index: number) {
+    setItems((current) => (current.length === 1 ? current : current.filter((_, i) => i !== index)));
+  }
+
+  async function handleSave() {
+    if (items.some((item) => !item.drugId || !item.dose || !item.route || !item.frequency)) {
+      window.alert('Please complete all required medication details.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const response = await fetchJSON(`/visits/${visitId}/prescriptions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          patientId,
+          notes,
+          items: items.map((item) => ({
+            ...item,
+            durationDays: Number(item.durationDays) || 1,
+            quantityPrescribed: Number(item.quantityPrescribed) || 1,
+          })),
+        }),
+      });
+      const allergyHits = (response as { allergyHits?: string[] }).allergyHits ?? [];
+      if (allergyHits.length) {
+        window.alert(`Allergy warning: ${allergyHits.join(', ')}`);
+      } else {
+        window.alert('Prescription created.');
+      }
+      setItems([{ ...DEFAULT_ITEM }]);
+      setNotes('');
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : 'Unable to save prescription');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <aside className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Prescribe (MVP)</h2>
+          <p className="text-xs text-gray-500">Enter the drug IDs from the drug master to send an e-prescription.</p>
+        </div>
+        <button
+          type="button"
+          onClick={addItem}
+          className="inline-flex items-center justify-center rounded-full border border-gray-300 px-3 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-100"
+        >
+          + Add item
+        </button>
+      </div>
+      <div className="mt-4 space-y-4">
+        {items.map((item, index) => (
+          <div key={index} className="rounded-xl border border-gray-200 bg-gray-50 p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">Medication #{index + 1}</span>
+              {items.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => removeItem(index)}
+                  className="text-xs font-semibold text-red-600 hover:underline"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              <label className="space-y-1 text-xs font-medium text-gray-600">
+                <span>Drug UUID</span>
+                <input
+                  value={item.drugId}
+                  onChange={(event) => updateItem(index, { drugId: event.target.value })}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  placeholder="00000000-0000-0000-0000-000000000001"
+                />
+              </label>
+              <label className="space-y-1 text-xs font-medium text-gray-600">
+                <span>Dose</span>
+                <input
+                  value={item.dose}
+                  onChange={(event) => updateItem(index, { dose: event.target.value })}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  placeholder="500 mg"
+                />
+              </label>
+              <label className="space-y-1 text-xs font-medium text-gray-600">
+                <span>Route</span>
+                <input
+                  value={item.route}
+                  onChange={(event) => updateItem(index, { route: event.target.value })}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  placeholder="PO"
+                />
+              </label>
+              <label className="space-y-1 text-xs font-medium text-gray-600">
+                <span>Frequency</span>
+                <input
+                  value={item.frequency}
+                  onChange={(event) => updateItem(index, { frequency: event.target.value })}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  placeholder="TID"
+                />
+              </label>
+              <label className="space-y-1 text-xs font-medium text-gray-600">
+                <span>Duration (days)</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={30}
+                  value={item.durationDays}
+                  onChange={(event) => updateItem(index, { durationDays: Number(event.target.value) })}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                />
+              </label>
+              <label className="space-y-1 text-xs font-medium text-gray-600">
+                <span>Quantity</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={200}
+                  value={item.quantityPrescribed}
+                  onChange={(event) => updateItem(index, { quantityPrescribed: Number(event.target.value) })}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                />
+              </label>
+            </div>
+          </div>
+        ))}
+      </div>
+      <label className="mt-4 block text-xs font-medium text-gray-600">
+        <span className="mb-1 block">Notes (optional)</span>
+        <textarea
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          rows={3}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          placeholder="Take after meals"
+        />
+      </label>
+      <button
+        type="button"
+        onClick={handleSave}
+        disabled={saving}
+        className="mt-4 inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+      >
+        {saving ? 'Saving…' : 'Save & Sign'}
+      </button>
+    </aside>
+  );
+}

--- a/client/src/components/icons.tsx
+++ b/client/src/components/icons.tsx
@@ -50,6 +50,16 @@ export function ReportsIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+export function PharmacyIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+      <rect x={3.75} y={8} width={16.5} height={8} rx={4} ry={4} />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9.75v4.5" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 12h4.5" />
+    </svg>
+  );
+}
+
 export function SettingsIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>

--- a/client/src/pages/DispenseDetail.tsx
+++ b/client/src/pages/DispenseDetail.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+import { fetchJSON } from '../api/http';
+
+interface PrescriptionItem {
+  itemId: string;
+  drugId: string;
+  dose: string;
+  route: string;
+  frequency: string;
+  durationDays: number;
+  quantityPrescribed: number;
+}
+
+interface PrescriptionDetail {
+  prescriptionId: string;
+  status: string;
+  patient?: { name: string };
+  doctor?: { name: string };
+  items: PrescriptionItem[];
+}
+
+interface DispenseSession {
+  dispenseId: string;
+  status: string;
+}
+
+export default function DispenseDetail() {
+  const { prescriptionId } = useParams<{ prescriptionId: string }>();
+  const navigate = useNavigate();
+  const [prescription, setPrescription] = useState<PrescriptionDetail | null>(null);
+  const [dispense, setDispense] = useState<DispenseSession | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      if (!prescriptionId) {
+        setError('Missing prescription reference.');
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const listResponse = await fetchJSON('/prescriptions?status=PENDING,PARTIAL');
+        const items = (listResponse as { data?: PrescriptionDetail[] }).data ?? [];
+        const found = items.find((item) => item.prescriptionId === prescriptionId);
+        if (!found) {
+          setError('Prescription not available for dispensing.');
+          setLoading(false);
+          return;
+        }
+        if (!cancelled) {
+          setPrescription(found);
+        }
+
+        const dispenseResponse = await fetchJSON(`/prescriptions/${prescriptionId}/dispenses`, {
+          method: 'POST',
+        });
+        if (!cancelled) {
+          setDispense(dispenseResponse as DispenseSession);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unable to load dispensing workspace');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [prescriptionId]);
+
+  async function handleAllocate(item: PrescriptionItem) {
+    if (!dispense) return;
+    try {
+      await fetchJSON(`/dispenses/${dispense.dispenseId}/items`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prescriptionItemId: item.itemId,
+          drugId: item.drugId,
+          quantity: item.quantityPrescribed,
+          stockItemId: null,
+        }),
+      });
+      window.alert('Allocated using default quantity. You can adjust FEFO selections in future iterations.');
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : 'Unable to allocate item');
+    }
+  }
+
+  async function handleComplete(nextStatus: 'COMPLETED' | 'PARTIAL') {
+    if (!dispense) return;
+    try {
+      await fetchJSON(`/dispenses/${dispense.dispenseId}/complete`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: nextStatus }),
+      });
+      window.alert('Dispense saved.');
+      navigate('/pharmacy/queue');
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : 'Unable to complete dispense');
+    }
+  }
+
+  const title = prescription ? `Dispense for ${prescription.patient?.name ?? 'Patient'}` : 'Dispense';
+  const subtitle = error
+    ? error
+    : loading
+      ? 'Loading dispensing workspace…'
+      : `Prepare items ordered by ${prescription?.doctor?.name ?? 'physician'}.`;
+
+  return (
+    <DashboardLayout title={title} subtitle={subtitle} activeItem="pharmacy">
+      {loading ? (
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-600 shadow-sm">Loading…</div>
+      ) : error ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700 shadow-sm">{error}</div>
+      ) : prescription && dispense ? (
+        <div className="space-y-6">
+          <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <header className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h1 className="text-lg font-semibold text-gray-900">Prescription Items</h1>
+                <p className="text-sm text-gray-600">Allocate stock to each line before completing the dispense.</p>
+              </div>
+              <span className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-600">
+                Session #{dispense.dispenseId.slice(0, 8)}
+              </span>
+            </header>
+            <div className="mt-4 space-y-4">
+              {prescription.items.map((item) => (
+                <div key={item.itemId} className="flex flex-wrap items-center justify-between gap-4 rounded-xl border border-gray-200 bg-gray-50 p-4">
+                  <div>
+                    <div className="text-sm font-semibold text-gray-900">{item.dose}</div>
+                    <div className="text-xs text-gray-600">
+                      {item.route} • {item.frequency} • {item.durationDays} days
+                    </div>
+                    <div className="mt-1 text-xs font-semibold text-gray-500">Qty prescribed: {item.quantityPrescribed}</div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleAllocate(item)}
+                    className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+                  >
+                    Allocate (MVP)
+                  </button>
+                </div>
+              ))}
+            </div>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={() => handleComplete('COMPLETED')}
+                className="inline-flex items-center justify-center rounded-full bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-green-700"
+              >
+                Complete Dispense
+              </button>
+              <button
+                type="button"
+                onClick={() => handleComplete('PARTIAL')}
+                className="inline-flex items-center justify-center rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-100"
+              >
+                Mark Partial
+              </button>
+            </div>
+          </section>
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-600 shadow-sm">
+          Unable to load prescription details.
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -317,6 +317,9 @@ const ACCOUNT_ROLE_LABELS: Record<UserAccount['role'], string> = {
   Doctor: 'Doctor',
   AdminAssistant: 'Administrative Assistant',
   ITAdmin: 'IT Administrator',
+  Pharmacist: 'Pharmacist',
+  PharmacyTech: 'Pharmacy Technician',
+  InventoryManager: 'Inventory Manager',
 };
 
 const STATUS_LABELS: Record<UserAccount['status'], 'Active' | 'Inactive'> = {

--- a/client/src/pages/PharmacyQueue.tsx
+++ b/client/src/pages/PharmacyQueue.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+import { fetchJSON } from '../api/http';
+
+interface QueueItem {
+  prescriptionId: string;
+  status: string;
+  notes?: string | null;
+  createdAt: string;
+  patient?: { patientId: string; name: string };
+  doctor?: { doctorId: string; name: string };
+  items: Array<{
+    itemId: string;
+    drugId: string;
+    dose: string;
+    route: string;
+    frequency: string;
+    durationDays: number;
+    quantityPrescribed: number;
+  }>;
+}
+
+const STATUS_OPTIONS = ['PENDING', 'PARTIAL', 'DISPENSED'] as const;
+
+type StatusOption = (typeof STATUS_OPTIONS)[number];
+
+export default function PharmacyQueue() {
+  const [status, setStatus] = useState<StatusOption>('PENDING');
+  const [data, setData] = useState<QueueItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetchJSON(`/prescriptions?status=${status}`);
+        if (!cancelled) {
+          setData((response as { data?: QueueItem[] }).data ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unable to load queue');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [status]);
+
+  const subtitle = useMemo(() => {
+    if (loading) return 'Loading pharmacy worklist…';
+    if (error) return error;
+    if (!data.length) return 'No prescriptions waiting in this state.';
+    return `${data.length} prescription${data.length === 1 ? '' : 's'} queued.`;
+  }, [data.length, error, loading]);
+
+  return (
+    <DashboardLayout title="Pharmacy" subtitle={subtitle} activeItem="pharmacy">
+      <div className="space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-4 rounded-2xl bg-white p-4 shadow-sm">
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900">Dispensing Queue</h1>
+            <p className="text-sm text-gray-600">Monitor incoming e-prescriptions and jump into dispensing.</p>
+          </div>
+          <select
+            value={status}
+            onChange={(event) => setStatus(event.target.value as StatusOption)}
+            className="rounded-full border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          >
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {loading ? (
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-600 shadow-sm">
+            Loading prescriptions…
+          </div>
+        ) : error ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700 shadow-sm">
+            {error}
+          </div>
+        ) : data.length === 0 ? (
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-600 shadow-sm">
+            Nothing in the queue for this status.
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {data.map((item) => (
+              <article key={item.prescriptionId} className="flex h-full flex-col rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-xs uppercase tracking-wide text-blue-600">Rx #{item.prescriptionId.slice(0, 8)}</div>
+                    <h2 className="text-base font-semibold text-gray-900">{item.patient?.name ?? 'Patient'}</h2>
+                    <p className="text-xs text-gray-500">Ordered by {item.doctor?.name ?? 'Doctor'}</p>
+                  </div>
+                  <span className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-600">{item.status}</span>
+                </div>
+
+                <ul className="mt-4 flex-1 space-y-2 text-sm text-gray-700">
+                  {item.items.map((line) => (
+                    <li key={line.itemId} className="flex items-start justify-between gap-2">
+                      <div>
+                        <div className="font-medium">{line.dose}</div>
+                        <div className="text-xs text-gray-500">
+                          {line.route} • {line.frequency} • {line.durationDays} days
+                        </div>
+                      </div>
+                      <span className="text-xs font-semibold text-gray-500">Qty {line.quantityPrescribed}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <Link
+                  to={`/pharmacy/dispense/${item.prescriptionId}`}
+                  className="mt-4 inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+                >
+                  Start Dispense
+                </Link>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -25,12 +25,18 @@ const ROLE_LABELS: Record<Role, string> = {
   Doctor: 'Doctor',
   AdminAssistant: 'Administrative Assistant',
   ITAdmin: 'IT Administrator',
+  Pharmacist: 'Pharmacist',
+  PharmacyTech: 'Pharmacy Technician',
+  InventoryManager: 'Inventory Manager',
 };
 
 const ROLE_OPTIONS: Array<{ value: Role; label: string }> = [
   { value: 'Doctor', label: ROLE_LABELS.Doctor },
   { value: 'AdminAssistant', label: ROLE_LABELS.AdminAssistant },
   { value: 'ITAdmin', label: ROLE_LABELS.ITAdmin },
+  { value: 'Pharmacist', label: ROLE_LABELS.Pharmacist },
+  { value: 'PharmacyTech', label: ROLE_LABELS.PharmacyTech },
+  { value: 'InventoryManager', label: ROLE_LABELS.InventoryManager },
 ];
 
 const DAY_OPTIONS = [

--- a/client/src/pages/VisitDetail.tsx
+++ b/client/src/pages/VisitDetail.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import DashboardLayout from '../components/DashboardLayout';
 import { PatientsIcon, SearchIcon } from '../components/icons';
+import PrescribeDrawer from '../components/PrescribeDrawer';
+import { useAuth } from '../context/AuthProvider';
 import {
   addObservation,
   getPatient,
@@ -76,6 +78,7 @@ export default function VisitDetail() {
   const [patient, setPatient] = useState<Patient | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { user } = useAuth();
 
   useEffect(() => {
     const visitId = id;
@@ -271,6 +274,12 @@ export default function VisitDetail() {
               </div>
             </div>
           </section>
+
+          {user?.role === 'Doctor' && (
+            <section className="rounded-2xl bg-white p-6 shadow-sm">
+              <PrescribeDrawer visitId={visit.visitId} patientId={patient.patientId} />
+            </section>
+          )}
 
           <section className="rounded-2xl bg-white p-6 shadow-sm">
             <div className="flex items-start justify-between gap-4">

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,9 @@
   "packages": {
     "": {
       "name": "atenxion-emr",
+      "hasInstallScript": true,
       "dependencies": {
+        "@prisma/client": "^6.15.0",
         "bcrypt": "^5",
         "cors": "^2",
         "csv-parse": "^6.1.0",
@@ -13,12 +15,14 @@
         "express-rate-limit": "^7",
         "helmet": "^7",
         "morgan": "^1",
-        "zod": "^3",
-        "@prisma/client": "^6.15.0",
-        "prisma": "^6.15.0"
+        "prisma": "^6.15.0",
+        "zod": "^3"
       },
       "devDependencies": {
+        "@types/cors": "^2",
+        "@types/express": "^4",
         "@types/jest": "^29",
+        "@types/morgan": "^1",
         "@types/node": "^20.19.13",
         "@types/supertest": "^2",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
@@ -1799,7 +1803,6 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.15.0.tgz",
       "integrity": "sha512-wR2LXUbOH4cL/WToatI/Y2c7uzni76oNFND7+23ypLllBmIS8e3ZHhO+nud9iXSXKFt1SoM3fTZvHawg63emZw==",
-      "dev": false,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1822,7 +1825,6 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.15.0.tgz",
       "integrity": "sha512-KMEoec9b2u6zX0EbSEx/dRpx1oNLjqJEBZYyK0S3TTIbZ7GEGoVyGyFRk4C72+A38cuPLbfQGQvgOD+gBErKlA==",
-      "dev": false,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -1835,14 +1837,12 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.15.0.tgz",
       "integrity": "sha512-y7cSeLuQmyt+A3hstAs6tsuAiVXSnw9T55ra77z0nbNkA8Lcq9rNcQg6PI00by/+WnE/aMRJ/W7sZWn2cgIy1g==",
-      "dev": false,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.15.0.tgz",
       "integrity": "sha512-opITiR5ddFJ1N2iqa7mkRlohCZqVSsHhRcc29QXeldMljOf4FSellLT0J5goVb64EzRTKcIDeIsJBgmilNcKxA==",
-      "dev": false,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1856,14 +1856,12 @@
       "version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb.tgz",
       "integrity": "sha512-a/46aK5j6L3ePwilZYEgYDPrhBQ/n4gYjLxT5YncUTJJNRnTCVjPF86QdzUOLRdYjCLfhtZp9aum90W0J+trrg==",
-      "dev": false,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.15.0.tgz",
       "integrity": "sha512-xcT5f6b+OWBq6vTUnRCc7qL+Im570CtwvgSj+0MTSGA1o9UDSKZ/WANvwtiRXdbYWECpyC3CukoG3A04VTAPHw==",
-      "dev": false,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.15.0",
@@ -1875,7 +1873,6 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.15.0.tgz",
       "integrity": "sha512-Jbb+Xbxyp05NSR1x2epabetHiXvpO8tdN2YNoWoA/ZsbYyxxu/CO/ROBauIFuMXs3Ti+W7N7SJtWsHGaWte9Rg==",
-      "dev": false,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.15.0"
@@ -1912,7 +1909,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
@@ -1988,6 +1984,27 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -1995,12 +2012,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -2011,6 +2064,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2064,6 +2124,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/morgan": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
+      "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
@@ -2072,6 +2149,43 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -2871,12 +2985,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2897,7 +3005,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
       "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -2926,7 +3033,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -2942,7 +3048,6 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -2955,7 +3060,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -3142,7 +3246,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -3275,14 +3378,12 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
       "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -3460,7 +3561,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -3470,7 +3570,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -3502,7 +3601,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/destroy": {
@@ -3602,15 +3700,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3621,7 +3710,6 @@
       "version": "3.16.12",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
       "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -3658,7 +3746,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -4168,14 +4255,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
       "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -4598,7 +4683,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -5714,7 +5798,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5794,27 +5877,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jwa": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5882,42 +5944,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "license": "MIT"
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5930,12 +5956,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -6279,7 +6299,6 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-int64": {
@@ -6351,7 +6370,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.1.tgz",
       "integrity": "sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -6392,7 +6410,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -6588,14 +6605,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -6701,7 +6716,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
       "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.2",
@@ -6751,7 +6765,6 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.15.0.tgz",
       "integrity": "sha512-E6RCgOt+kUVtjtZgLQDBJ6md2tDItLJNExwI0XJeBc1FKL+Vwb+ovxXxuok9r8oBgsOXBA33fGDuE/0qDdCWqQ==",
-      "dev": false,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6814,7 +6827,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6891,7 +6903,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -7609,7 +7620,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmpl": {
@@ -7929,7 +7939,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand",
     "lint": "eslint .",
     "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev",
+    "prisma:migrate": "prisma migrate dev --name pharmacy_mvp",
+    "prisma:seed": "tsx prisma/seed.mts",
     "seed": "prisma db seed",
     "reset:db": "prisma migrate reset --force",
     "studio": "prisma studio"
   },
   "prisma": {
-    "seed": "node prisma/seed.mjs"
+    "seed": "tsx prisma/seed.mts"
   },
   "devDependencies": {
     "@types/jest": "^29",

--- a/prisma/migrations/20250215000005_pharmacy_mvp/migration.sql
+++ b/prisma/migrations/20250215000005_pharmacy_mvp/migration.sql
@@ -1,0 +1,109 @@
+-- Extend Role enum for pharmacy workforce
+ALTER TYPE "Role" ADD VALUE IF NOT EXISTS 'Pharmacist';
+ALTER TYPE "Role" ADD VALUE IF NOT EXISTS 'PharmacyTech';
+ALTER TYPE "Role" ADD VALUE IF NOT EXISTS 'InventoryManager';
+
+-- New enums for prescription lifecycle
+CREATE TYPE "PrescriptionStatus" AS ENUM ('PENDING', 'PARTIAL', 'DISPENSED', 'CANCELLED');
+CREATE TYPE "DispenseStatus" AS ENUM ('READY', 'PARTIAL', 'COMPLETED', 'CANCELLED');
+
+-- Core pharmacy reference data
+CREATE TABLE "Drug" (
+    "drugId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" TEXT NOT NULL,
+    "genericName" TEXT,
+    "form" TEXT NOT NULL,
+    "strength" TEXT NOT NULL,
+    "routeDefault" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT TRUE,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Drug_pkey" PRIMARY KEY ("drugId")
+);
+
+CREATE TABLE "StockItem" (
+    "stockItemId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "drugId" UUID NOT NULL,
+    "batchNo" TEXT,
+    "expiryDate" TIMESTAMPTZ(3),
+    "location" TEXT NOT NULL,
+    "qtyOnHand" INTEGER NOT NULL DEFAULT 0,
+    "unitCost" DECIMAL(10, 2),
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "StockItem_pkey" PRIMARY KEY ("stockItemId"),
+    CONSTRAINT "StockItem_drugId_fkey" FOREIGN KEY ("drugId") REFERENCES "Drug"("drugId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Prescription authoring
+CREATE TABLE "Prescription" (
+    "prescriptionId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "visitId" UUID NOT NULL,
+    "doctorId" UUID NOT NULL,
+    "patientId" UUID NOT NULL,
+    "status" "PrescriptionStatus" NOT NULL DEFAULT 'PENDING',
+    "notes" TEXT,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Prescription_pkey" PRIMARY KEY ("prescriptionId"),
+    CONSTRAINT "Prescription_visitId_fkey" FOREIGN KEY ("visitId") REFERENCES "Visit"("visitId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Prescription_doctorId_fkey" FOREIGN KEY ("doctorId") REFERENCES "Doctor"("doctorId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Prescription_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("patientId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "PrescriptionItem" (
+    "itemId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "prescriptionId" UUID NOT NULL,
+    "drugId" UUID NOT NULL,
+    "dose" TEXT NOT NULL,
+    "route" TEXT NOT NULL,
+    "frequency" TEXT NOT NULL,
+    "durationDays" INTEGER NOT NULL,
+    "quantityPrescribed" INTEGER NOT NULL,
+    "prn" BOOLEAN NOT NULL DEFAULT FALSE,
+    "allowGeneric" BOOLEAN NOT NULL DEFAULT TRUE,
+    "notes" TEXT,
+    CONSTRAINT "PrescriptionItem_pkey" PRIMARY KEY ("itemId"),
+    CONSTRAINT "PrescriptionItem_prescriptionId_fkey" FOREIGN KEY ("prescriptionId") REFERENCES "Prescription"("prescriptionId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "PrescriptionItem_drugId_fkey" FOREIGN KEY ("drugId") REFERENCES "Drug"("drugId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- Dispensing workflow
+CREATE TABLE "Dispense" (
+    "dispenseId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "prescriptionId" UUID NOT NULL,
+    "pharmacistId" UUID NOT NULL,
+    "status" "DispenseStatus" NOT NULL DEFAULT 'READY',
+    "dispensedAt" TIMESTAMPTZ(3),
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Dispense_pkey" PRIMARY KEY ("dispenseId"),
+    CONSTRAINT "Dispense_prescriptionId_fkey" FOREIGN KEY ("prescriptionId") REFERENCES "Prescription"("prescriptionId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Dispense_pharmacistId_fkey" FOREIGN KEY ("pharmacistId") REFERENCES "User"("userId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "DispenseItem" (
+    "dispenseItemId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "dispenseId" UUID NOT NULL,
+    "prescriptionItemId" UUID NOT NULL,
+    "stockItemId" UUID,
+    "drugId" UUID NOT NULL,
+    "quantity" INTEGER NOT NULL,
+    "unitPrice" DECIMAL(10, 2),
+    CONSTRAINT "DispenseItem_pkey" PRIMARY KEY ("dispenseItemId"),
+    CONSTRAINT "DispenseItem_dispenseId_fkey" FOREIGN KEY ("dispenseId") REFERENCES "Dispense"("dispenseId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "DispenseItem_prescriptionItemId_fkey" FOREIGN KEY ("prescriptionItemId") REFERENCES "PrescriptionItem"("itemId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "DispenseItem_stockItemId_fkey" FOREIGN KEY ("stockItemId") REFERENCES "StockItem"("stockItemId") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "DispenseItem_drugId_fkey" FOREIGN KEY ("drugId") REFERENCES "Drug"("drugId") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- Indexing to support queue and FEFO lookups
+CREATE INDEX "Prescription_visitId_status_idx" ON "Prescription"("visitId", "status");
+CREATE INDEX "Prescription_patientId_status_idx" ON "Prescription"("patientId", "status");
+CREATE INDEX "PrescriptionItem_prescriptionId_idx" ON "PrescriptionItem"("prescriptionId");
+CREATE INDEX "Dispense_prescriptionId_idx" ON "Dispense"("prescriptionId");
+CREATE INDEX "DispenseItem_dispenseId_idx" ON "DispenseItem"("dispenseId");
+CREATE INDEX "DispenseItem_prescriptionItemId_idx" ON "DispenseItem"("prescriptionItemId");
+CREATE INDEX "StockItem_drugId_idx" ON "StockItem"("drugId");
+CREATE INDEX "StockItem_location_idx" ON "StockItem"("location");
+CREATE INDEX "StockItem_expiryDate_idx" ON "StockItem"("expiryDate");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,9 @@ enum Role {
   Doctor
   AdminAssistant
   ITAdmin
+  Pharmacist
+  PharmacyTech
+  InventoryManager
 }
 
 enum AppointmentStatus {
@@ -43,6 +46,7 @@ model Patient {
   appointments Appointment[]
   visits       Visit[]
   observations Observation[]
+  prescriptions Prescription[]
 }
 
 model Doctor {
@@ -57,6 +61,7 @@ model Doctor {
   visits       Visit[]
   observations Observation[]
   user         User?
+  prescriptions Prescription[]
 }
 
 model Appointment {
@@ -120,6 +125,7 @@ model Visit {
   medications  Medication[]
   labResults   LabResult[]
   observations Observation[]
+  prescriptions Prescription[]
 
   @@index([patientId, visitDate(sort: Desc)])
   @@index([doctorId, visitDate(sort: Desc)])
@@ -191,6 +197,7 @@ model User {
 
   doctor   Doctor?  @relation(fields: [doctorId], references: [doctorId])
   sessions Session[]
+  dispenses Dispense[]
 
   @@unique([doctorId])
 }
@@ -215,4 +222,127 @@ model AuthAudit {
   outcome String
   meta    Json?
   ts      DateTime @default(now())
+}
+
+model Drug {
+  drugId       String   @id @default(uuid()) @db.Uuid
+  name         String
+  genericName  String?
+  form         String
+  strength     String
+  routeDefault String?
+  isActive     Boolean  @default(true)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  stocks              StockItem[]
+  prescriptionItems   PrescriptionItem[]
+  dispenseItems       DispenseItem[]
+}
+
+model Prescription {
+  prescriptionId String              @id @default(uuid()) @db.Uuid
+  visitId        String              @db.Uuid
+  doctorId       String              @db.Uuid
+  patientId      String              @db.Uuid
+  status         PrescriptionStatus  @default(PENDING)
+  notes          String?
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
+
+  visit       Visit   @relation(fields: [visitId], references: [visitId], onDelete: Cascade)
+  doctor      Doctor  @relation(fields: [doctorId], references: [doctorId], onDelete: Cascade)
+  patient     Patient @relation(fields: [patientId], references: [patientId], onDelete: Cascade)
+  items       PrescriptionItem[]
+  dispenses   Dispense[]
+
+  @@index([visitId, status])
+  @@index([patientId, status])
+}
+
+model PrescriptionItem {
+  itemId             String             @id @default(uuid()) @db.Uuid
+  prescriptionId     String             @db.Uuid
+  drugId             String             @db.Uuid
+  dose               String
+  route              String
+  frequency          String
+  durationDays       Int
+  quantityPrescribed Int
+  prn                Boolean           @default(false)
+  allowGeneric       Boolean           @default(true)
+  notes              String?
+
+  prescription Prescription @relation(fields: [prescriptionId], references: [prescriptionId], onDelete: Cascade)
+  drug         Drug         @relation(fields: [drugId], references: [drugId])
+  dispenseItems DispenseItem[]
+
+  @@index([prescriptionId])
+}
+
+model Dispense {
+  dispenseId     String          @id @default(uuid()) @db.Uuid
+  prescriptionId String          @db.Uuid
+  pharmacistId   String          @db.Uuid
+  status         DispenseStatus  @default(READY)
+  dispensedAt    DateTime?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+
+  prescription Prescription @relation(fields: [prescriptionId], references: [prescriptionId], onDelete: Cascade)
+  pharmacist   User         @relation(fields: [pharmacistId], references: [userId], onDelete: Restrict)
+  items        DispenseItem[]
+
+  @@index([prescriptionId])
+}
+
+model DispenseItem {
+  dispenseItemId     String    @id @default(uuid()) @db.Uuid
+  dispenseId         String    @db.Uuid
+  prescriptionItemId String    @db.Uuid
+  stockItemId        String?   @db.Uuid
+  drugId             String    @db.Uuid
+  quantity           Int
+  unitPrice          Decimal?  @db.Decimal(10, 2)
+
+  dispense          Dispense        @relation(fields: [dispenseId], references: [dispenseId], onDelete: Cascade)
+  prescriptionItem  PrescriptionItem @relation(fields: [prescriptionItemId], references: [itemId], onDelete: Cascade)
+  stockItem         StockItem?      @relation(fields: [stockItemId], references: [stockItemId], onDelete: SetNull)
+  drug              Drug            @relation(fields: [drugId], references: [drugId])
+
+  @@index([dispenseId])
+  @@index([prescriptionItemId])
+}
+
+model StockItem {
+  stockItemId String    @id @default(uuid()) @db.Uuid
+  drugId      String    @db.Uuid
+  batchNo     String?
+  expiryDate  DateTime?
+  location    String
+  qtyOnHand   Int       @default(0)
+  unitCost    Decimal?  @db.Decimal(10, 2)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  drug        Drug      @relation(fields: [drugId], references: [drugId], onDelete: Cascade)
+  dispenseItems DispenseItem[]
+
+  @@index([drugId])
+  @@index([location])
+  @@index([expiryDate])
+}
+
+enum PrescriptionStatus {
+  PENDING
+  PARTIAL
+  DISPENSED
+  CANCELLED
+}
+
+enum DispenseStatus {
+  READY
+  PARTIAL
+  COMPLETED
+  CANCELLED
 }

--- a/prisma/seed.mts
+++ b/prisma/seed.mts
@@ -1,0 +1,74 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function seedPharmacyReference() {
+  const drugs = await prisma.$transaction([
+    prisma.drug.upsert({
+      where: { drugId: '00000000-0000-0000-0000-000000000001' },
+      update: {},
+      create: {
+        drugId: '00000000-0000-0000-0000-000000000001',
+        name: 'Amoxicillin',
+        genericName: 'amoxicillin',
+        form: 'tab',
+        strength: '500 mg',
+        routeDefault: 'PO',
+      },
+    }),
+    prisma.drug.upsert({
+      where: { drugId: '00000000-0000-0000-0000-000000000002' },
+      update: {},
+      create: {
+        drugId: '00000000-0000-0000-0000-000000000002',
+        name: 'Paracetamol',
+        genericName: 'acetaminophen',
+        form: 'tab',
+        strength: '500 mg',
+        routeDefault: 'PO',
+      },
+    }),
+    prisma.drug.upsert({
+      where: { drugId: '00000000-0000-0000-0000-000000000003' },
+      update: {},
+      create: {
+        drugId: '00000000-0000-0000-0000-000000000003',
+        name: 'Ibuprofen',
+        genericName: 'ibuprofen',
+        form: 'tab',
+        strength: '200 mg',
+        routeDefault: 'PO',
+      },
+    }),
+  ]);
+
+  for (const drug of drugs) {
+    await prisma.stockItem.create({
+      data: {
+        drugId: drug.drugId,
+        batchNo: `BATCH-${drug.drugId.slice(-4)}`,
+        expiryDate: new Date('2026-12-31'),
+        location: 'COUNTER_A',
+        qtyOnHand: 200,
+        unitCost: 100.0,
+      },
+    });
+  }
+
+  console.log('✅ Seeded drugs + stock');
+}
+
+async function main() {
+  // Run legacy seed first to ensure baseline data remains available.
+  await import('./seed.mjs');
+  await seedPharmacyReference();
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -3,7 +3,13 @@ import type { Request } from 'express';
 import bcrypt from 'bcrypt';
 import { PrismaClient } from '@prisma/client';
 
-type RoleName = 'Doctor' | 'AdminAssistant' | 'ITAdmin';
+type RoleName =
+  | 'Doctor'
+  | 'AdminAssistant'
+  | 'ITAdmin'
+  | 'Pharmacist'
+  | 'PharmacyTech'
+  | 'InventoryManager';
 
 export interface AuthUser {
   userId: string;

--- a/src/routes/pharmacy.ts
+++ b/src/routes/pharmacy.ts
@@ -1,0 +1,177 @@
+import { Router } from 'express';
+import { PrismaClient, PrescriptionStatus } from '@prisma/client';
+import { z } from 'zod';
+
+import { requireAuth, requireRole, type AuthRequest } from '../modules/auth/index.js';
+import { validate } from '../middleware/validate.js';
+import {
+  CreateRxSchema,
+  DispenseItemSchema,
+  ReceiveStockSchema,
+  type CreateRxInput,
+  type DispenseItemInput,
+} from '../validation/pharmacy.js';
+import {
+  addDispenseItem,
+  completeDispense,
+  createPrescription,
+  getPharmacyQueue,
+  receiveStock,
+  startDispense,
+} from '../services/pharmacyService.js';
+
+const prisma = new PrismaClient();
+const router = Router();
+
+const CreateDrugSchema = z.object({
+  drugId: z.string().uuid().optional(),
+  name: z.string().min(1),
+  genericName: z.string().optional(),
+  form: z.string().min(1),
+  strength: z.string().min(1),
+  routeDefault: z.string().optional(),
+  isActive: z.boolean().optional(),
+});
+
+const CompleteDispenseSchema = z.object({
+  status: z.enum(['COMPLETED', 'PARTIAL']),
+});
+
+router.use(requireAuth);
+
+router.post(
+  '/drugs',
+  requireRole('ITAdmin'),
+  validate({ body: CreateDrugSchema }),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const body = req.body as z.infer<typeof CreateDrugSchema>;
+      const drug = await prisma.drug.create({ data: body });
+      res.status(201).json(drug);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/inventory/receive',
+  requireRole('ITAdmin', 'InventoryManager', 'Pharmacist'),
+  validate({ body: ReceiveStockSchema }),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const payload = req.body as z.infer<typeof ReceiveStockSchema>;
+      const created = await receiveStock(payload.items);
+      res.status(201).json({ items: created });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/visits/:visitId/prescriptions',
+  requireRole('Doctor'),
+  validate({ body: CreateRxSchema }),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const visitId = req.params.visitId;
+      const payload = req.body as CreateRxInput;
+
+      const visit = await prisma.visit.findUnique({
+        where: { visitId },
+        select: { visitId: true, patientId: true, doctorId: true },
+      });
+
+      if (!visit) {
+        return res.status(404).json({ error: 'Visit not found' });
+      }
+
+      if (req.user?.doctorId && req.user.doctorId !== visit.doctorId) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+
+      const patientId = payload.patientId ?? visit.patientId;
+      const { prescription, allergyHits } = await createPrescription(
+        visitId,
+        visit.doctorId,
+        patientId,
+        payload,
+      );
+
+      res.status(201).json({ prescription, allergyHits });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/prescriptions',
+  requireRole('Pharmacist', 'PharmacyTech', 'ITAdmin'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const raw = typeof req.query.status === 'string' ? req.query.status.split(',') : undefined;
+      const statuses = (raw ?? ['PENDING']).reduce<PrescriptionStatus[]>((acc, value) => {
+        const normalized = value.trim().toUpperCase();
+        if ((Object.values(PrescriptionStatus) as string[]).includes(normalized)) {
+          acc.push(normalized as PrescriptionStatus);
+        }
+        return acc;
+      }, []);
+
+      const queue = await getPharmacyQueue(statuses.length ? statuses : [PrescriptionStatus.PENDING]);
+      res.json({ data: queue });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/prescriptions/:prescriptionId/dispenses',
+  requireRole('Pharmacist', 'PharmacyTech'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      const dispense = await startDispense(req.params.prescriptionId, req.user.userId);
+      res.status(201).json(dispense);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/dispenses/:dispenseId/items',
+  requireRole('Pharmacist', 'PharmacyTech'),
+  validate({ body: DispenseItemSchema }),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const payload = req.body as DispenseItemInput;
+      const item = await addDispenseItem(req.params.dispenseId, payload);
+      res.status(201).json(item);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.patch(
+  '/dispenses/:dispenseId/complete',
+  requireRole('Pharmacist'),
+  validate({ body: CompleteDispenseSchema }),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const body = req.body as z.infer<typeof CompleteDispenseSchema>;
+      const result = await completeDispense(req.params.dispenseId, body.status);
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import authRouter from './modules/auth/index.js';
 import appointmentsRouter from './routes/appointments.js';
 import usersRouter from './modules/users/index.js';
 import reportsRouter from './modules/reports/index.js';
+import pharmacyRouter from './routes/pharmacy.js';
 
 export const apiRouter = Router();
 
@@ -33,6 +34,7 @@ apiRouter.use('/auth', authRouter);
 apiRouter.use('/appointments', appointmentsRouter);
 apiRouter.use('/users', usersRouter);
 apiRouter.use('/reports', reportsRouter);
+apiRouter.use(pharmacyRouter);
 apiRouter.use(docsRouter);
 
 export default apiRouter;

--- a/src/services/pharmacyService.ts
+++ b/src/services/pharmacyService.ts
@@ -1,0 +1,206 @@
+import { PrismaClient, PrescriptionStatus, type DispenseStatus } from '@prisma/client';
+import type {
+  CreateRxInput,
+  DispenseItemInput,
+  ReceiveStockInput,
+} from '../validation/pharmacy.js';
+
+const prisma = new PrismaClient();
+
+export async function allocateFEFO(drugId: string, location: string, neededQty: number) {
+  const batches = await prisma.stockItem.findMany({
+    where: { drugId, location, qtyOnHand: { gt: 0 } },
+    orderBy: [{ expiryDate: 'asc' }, { createdAt: 'asc' }],
+  });
+  const picks: Array<{ stockItemId: string; qty: number }> = [];
+  let remaining = neededQty;
+  for (const batch of batches) {
+    if (remaining <= 0) break;
+    const take = Math.min(batch.qtyOnHand, remaining);
+    if (take > 0) {
+      picks.push({ stockItemId: batch.stockItemId, qty: take });
+      remaining -= take;
+    }
+  }
+  return { picks, remaining };
+}
+
+export async function checkAllergy(patientId: string, drugNames: string[]): Promise<string[]> {
+  try {
+    // @ts-ignore Optional table depending on deployment state.
+    const allergies = (await prisma.patientAllergy?.findMany({ where: { patientId } })) ?? [];
+    const alerts: string[] = [];
+    for (const allergy of allergies) {
+      const substance = String(allergy.substance ?? '').toLowerCase();
+      if (!substance) continue;
+      for (const drugName of drugNames) {
+        if (drugName.toLowerCase().includes(substance)) {
+          alerts.push(allergy.substance);
+          break;
+        }
+      }
+    }
+    return alerts;
+  } catch {
+    return [];
+  }
+}
+
+export async function createPrescription(
+  visitId: string,
+  doctorId: string,
+  patientId: string,
+  payload: CreateRxInput,
+) {
+  const drugIds = payload.items.map((item) => item.drugId);
+  const drugs = await prisma.drug.findMany({ where: { drugId: { in: drugIds } } });
+  const drugNames = drugs.map((drug) => `${drug.name} ${drug.strength}`.trim());
+
+  const allergyHits = patientId ? await checkAllergy(patientId, drugNames) : [];
+
+  const prescription = await prisma.prescription.create({
+    data: {
+      visitId,
+      doctorId,
+      patientId,
+      notes: payload.notes ?? null,
+      items: {
+        create: payload.items.map((item) => ({
+          drugId: item.drugId,
+          dose: item.dose,
+          route: item.route,
+          frequency: item.frequency,
+          durationDays: item.durationDays,
+          quantityPrescribed: item.quantityPrescribed,
+          prn: Boolean(item.prn),
+          allowGeneric: item.allowGeneric ?? true,
+          notes: item.notes ?? null,
+        })),
+      },
+    },
+    include: { items: true },
+  });
+
+  return { prescription, allergyHits };
+}
+
+export async function receiveStock(items: ReceiveStockInput) {
+  return prisma.$transaction(async (tx) => {
+    const created = [] as Array<{ stockItemId: string }>;
+    for (const item of items) {
+      created.push(
+        await tx.stockItem.create({
+          data: {
+            drugId: item.drugId,
+            batchNo: item.batchNo ?? null,
+            expiryDate: item.expiryDate ? new Date(item.expiryDate) : null,
+            location: item.location,
+            qtyOnHand: item.qtyOnHand,
+            unitCost: item.unitCost ?? null,
+          },
+        }),
+      );
+    }
+    return created;
+  });
+}
+
+export async function getPharmacyQueue(
+  status: PrescriptionStatus[] = [PrescriptionStatus.PENDING],
+) {
+  return prisma.prescription.findMany({
+    where: { status: { in: status } },
+    orderBy: { createdAt: 'desc' },
+    include: { items: true, patient: true, doctor: true },
+  });
+}
+
+export async function startDispense(prescriptionId: string, pharmacistId: string) {
+  return prisma.dispense.create({
+    data: {
+      prescriptionId,
+      pharmacistId,
+      status: 'READY',
+    },
+  });
+}
+
+export async function addDispenseItem(
+  dispenseId: string,
+  item: DispenseItemInput,
+) {
+  return prisma.dispenseItem.create({
+    data: {
+      dispenseId,
+      prescriptionItemId: item.prescriptionItemId,
+      stockItemId: item.stockItemId ?? null,
+      drugId: item.drugId,
+      quantity: item.quantity,
+      unitPrice: item.unitPrice ?? null,
+    },
+  });
+}
+
+export async function completeDispense(
+  dispenseId: string,
+  status: Extract<DispenseStatus, 'COMPLETED' | 'PARTIAL'>,
+) {
+  return prisma.$transaction(async (tx) => {
+    const dispense = await tx.dispense.findUnique({
+      where: { dispenseId },
+      include: {
+        items: true,
+        prescription: {
+          include: { items: true },
+        },
+      },
+    });
+
+    if (!dispense) {
+      throw new Error('NOT_FOUND');
+    }
+
+    for (const item of dispense.items) {
+      if (!item.stockItemId) continue;
+      const updated = await tx.stockItem.update({
+        where: { stockItemId: item.stockItemId },
+        data: { qtyOnHand: { decrement: item.quantity } },
+      });
+      if (updated.qtyOnHand < 0) {
+        throw new Error('OUT_OF_STOCK_RACE');
+      }
+    }
+
+    await tx.dispense.update({
+      where: { dispenseId },
+      data: {
+        status,
+        dispensedAt: new Date(),
+      },
+    });
+
+    const totals = await tx.dispenseItem.groupBy({
+      by: ['prescriptionItemId'],
+      _sum: { quantity: true },
+      where: {
+        dispense: {
+          prescriptionId: dispense.prescriptionId,
+        },
+      },
+    });
+
+    const allMet = dispense.prescription.items.every((rxItem) => {
+      const sum = totals.find((t) => t.prescriptionItemId === rxItem.itemId)?._sum.quantity ?? 0;
+      return sum >= rxItem.quantityPrescribed;
+    });
+
+    const finalStatus = allMet ? PrescriptionStatus.DISPENSED : PrescriptionStatus.PARTIAL;
+
+    await tx.prescription.update({
+      where: { prescriptionId: dispense.prescriptionId },
+      data: { status: finalStatus },
+    });
+
+    return { ok: true, prescriptionStatus: finalStatus };
+  });
+}

--- a/src/validation/pharmacy.ts
+++ b/src/validation/pharmacy.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+export const RxItemSchema = z.object({
+  drugId: z.string().uuid(),
+  dose: z.string().min(1),
+  route: z.string().min(1),
+  frequency: z.string().min(1),
+  durationDays: z.number().int().positive().max(30),
+  quantityPrescribed: z.number().int().positive().max(200),
+  prn: z.boolean().optional().default(false),
+  allowGeneric: z.boolean().optional().default(true),
+  notes: z.string().max(300).optional(),
+});
+
+export const CreateRxSchema = z.object({
+  patientId: z.string().uuid().optional(),
+  notes: z.string().max(500).optional(),
+  items: z.array(RxItemSchema).min(1).max(10),
+});
+
+export const ReceiveStockSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        drugId: z.string().uuid(),
+        batchNo: z.string().optional(),
+        expiryDate: z.string().datetime().optional(),
+        location: z.string().min(1),
+        qtyOnHand: z.number().int().nonnegative(),
+        unitCost: z.number().nonnegative().optional(),
+      }),
+    )
+    .min(1),
+});
+
+export const DispenseItemSchema = z.object({
+  prescriptionItemId: z.string().uuid(),
+  stockItemId: z.string().uuid().nullable().optional(),
+  drugId: z.string().uuid(),
+  quantity: z.number().int().positive().max(500),
+  unitPrice: z.number().nonnegative().optional(),
+});
+
+export type RxItemInput = z.infer<typeof RxItemSchema>;
+export type CreateRxInput = z.infer<typeof CreateRxSchema>;
+export type ReceiveStockInput = z.infer<typeof ReceiveStockSchema>['items'];
+export type DispenseItemInput = z.infer<typeof DispenseItemSchema>;

--- a/tests/pharmacy.spec.ts
+++ b/tests/pharmacy.spec.ts
@@ -1,0 +1,239 @@
+import request from 'supertest';
+import { PrismaClient, PrescriptionStatus } from '@prisma/client';
+import { app } from '../src/index';
+
+const prisma = new PrismaClient();
+
+function makeAuthHeader(userId: string, role: string, email: string) {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ sub: userId, role, email })).toString('base64url');
+  return `Bearer ${header}.${payload}.`;
+}
+
+let doctorId: string;
+let patientId: string;
+let visitId: string;
+let doctorUserId: string;
+let pharmacistUserId: string;
+let primaryDrugId: string;
+let primaryStockId: string;
+let primaryInitialQty: number;
+let secondaryDrugId: string;
+let secondaryStockId: string;
+let secondaryInitialQty: number;
+
+beforeAll(async () => {
+  const doctor = await prisma.doctor.create({ data: { name: 'Dr Pharma', department: 'Pharmacy' } });
+  doctorId = doctor.doctorId;
+  const patient = await prisma.patient.create({ data: { name: 'Pharma Patient', dob: new Date('1990-01-01'), gender: 'M' } });
+  patientId = patient.patientId;
+  const visit = await prisma.visit.create({
+    data: {
+      patientId,
+      doctorId,
+      visitDate: new Date('2024-01-01'),
+      department: 'Pharmacy',
+      reason: 'Medication review',
+    },
+  });
+  visitId = visit.visitId;
+
+  const doctorUser = await prisma.user.create({
+    data: {
+      email: 'pharma-doctor@example.com',
+      passwordHash: 'x',
+      role: 'Doctor',
+      doctorId,
+    },
+  });
+  doctorUserId = doctorUser.userId;
+
+  const pharmacistUser = await prisma.user.create({
+    data: {
+      email: 'rx@example.com',
+      passwordHash: 'x',
+      role: 'Pharmacist',
+    },
+  });
+  pharmacistUserId = pharmacistUser.userId;
+
+  const drug = await prisma.drug.create({
+    data: {
+      name: 'Test Drug A',
+      genericName: 'testa',
+      form: 'tab',
+      strength: '250 mg',
+    },
+  });
+  primaryDrugId = drug.drugId;
+  const stock = await prisma.stockItem.create({
+    data: {
+      drugId: primaryDrugId,
+      batchNo: 'A-001',
+      expiryDate: new Date('2026-01-01'),
+      location: 'COUNTER_A',
+      qtyOnHand: 50,
+    },
+  });
+  primaryStockId = stock.stockItemId;
+  primaryInitialQty = stock.qtyOnHand;
+
+  const drugB = await prisma.drug.create({
+    data: {
+      name: 'Test Drug B',
+      genericName: 'testb',
+      form: 'cap',
+      strength: '100 mg',
+    },
+  });
+  secondaryDrugId = drugB.drugId;
+  const stockB = await prisma.stockItem.create({
+    data: {
+      drugId: secondaryDrugId,
+      batchNo: 'B-001',
+      expiryDate: new Date('2026-06-01'),
+      location: 'COUNTER_A',
+      qtyOnHand: 40,
+    },
+  });
+  secondaryStockId = stockB.stockItemId;
+  secondaryInitialQty = stockB.qtyOnHand;
+});
+
+afterAll(async () => {
+  await prisma.dispenseItem.deleteMany({});
+  await prisma.dispense.deleteMany({});
+  await prisma.prescriptionItem.deleteMany({});
+  await prisma.prescription.deleteMany({});
+  await prisma.stockItem.deleteMany({ where: { stockItemId: { in: [primaryStockId, secondaryStockId] } } });
+  await prisma.drug.deleteMany({ where: { drugId: { in: [primaryDrugId, secondaryDrugId] } } });
+  await prisma.visit.deleteMany({ where: { visitId } });
+  await prisma.patient.deleteMany({ where: { patientId } });
+  await prisma.doctor.deleteMany({ where: { doctorId } });
+  await prisma.user.deleteMany({ where: { userId: { in: [doctorUserId, pharmacistUserId] } } });
+  await prisma.$disconnect();
+});
+
+describe('Pharmacy MVP', () => {
+  it('creates prescription and completes full dispense', async () => {
+    const doctorAuth = makeAuthHeader(doctorUserId, 'Doctor', 'pharma-doctor@example.com');
+    const pharmacistAuth = makeAuthHeader(pharmacistUserId, 'Pharmacist', 'rx@example.com');
+
+    const createRes = await request(app)
+      .post(`/api/visits/${visitId}/prescriptions`)
+      .set('Authorization', doctorAuth)
+      .send({
+        patientId,
+        notes: 'Take with food',
+        items: [
+          {
+            drugId: primaryDrugId,
+            dose: '250 mg',
+            route: 'PO',
+            frequency: 'TID',
+            durationDays: 5,
+            quantityPrescribed: 10,
+          },
+        ],
+      });
+
+    expect(createRes.status).toBe(201);
+    const prescription = createRes.body.prescription;
+    expect(prescription.items).toHaveLength(1);
+
+    const dispenseRes = await request(app)
+      .post(`/api/prescriptions/${prescription.prescriptionId}/dispenses`)
+      .set('Authorization', pharmacistAuth);
+
+    expect(dispenseRes.status).toBe(201);
+    const dispenseId = dispenseRes.body.dispenseId as string;
+
+    const dispenseItemRes = await request(app)
+      .post(`/api/dispenses/${dispenseId}/items`)
+      .set('Authorization', pharmacistAuth)
+      .send({
+        prescriptionItemId: prescription.items[0].itemId,
+        stockItemId: primaryStockId,
+        drugId: primaryDrugId,
+        quantity: 10,
+      });
+
+    expect(dispenseItemRes.status).toBe(201);
+
+    const completeRes = await request(app)
+      .patch(`/api/dispenses/${dispenseId}/complete`)
+      .set('Authorization', pharmacistAuth)
+      .send({ status: 'COMPLETED' });
+
+    expect(completeRes.status).toBe(200);
+    expect(completeRes.body.prescriptionStatus).toBe(PrescriptionStatus.DISPENSED);
+
+    const updatedPrescription = await prisma.prescription.findUnique({
+      where: { prescriptionId: prescription.prescriptionId },
+    });
+    expect(updatedPrescription?.status).toBe(PrescriptionStatus.DISPENSED);
+
+    const stock = await prisma.stockItem.findUnique({ where: { stockItemId: primaryStockId } });
+    expect(stock?.qtyOnHand).toBe(primaryInitialQty - 10);
+  });
+
+  it('supports partial dispense tracking', async () => {
+    const doctorAuth = makeAuthHeader(doctorUserId, 'Doctor', 'pharma-doctor@example.com');
+    const pharmacistAuth = makeAuthHeader(pharmacistUserId, 'Pharmacist', 'rx@example.com');
+
+    const createRes = await request(app)
+      .post(`/api/visits/${visitId}/prescriptions`)
+      .set('Authorization', doctorAuth)
+      .send({
+        patientId,
+        notes: 'Use as needed',
+        items: [
+          {
+            drugId: secondaryDrugId,
+            dose: '100 mg',
+            route: 'PO',
+            frequency: 'BID',
+            durationDays: 3,
+            quantityPrescribed: 12,
+          },
+        ],
+      });
+
+    expect(createRes.status).toBe(201);
+    const prescription = createRes.body.prescription;
+
+    const dispenseRes = await request(app)
+      .post(`/api/prescriptions/${prescription.prescriptionId}/dispenses`)
+      .set('Authorization', pharmacistAuth);
+
+    expect(dispenseRes.status).toBe(201);
+    const dispenseId = dispenseRes.body.dispenseId as string;
+
+    await request(app)
+      .post(`/api/dispenses/${dispenseId}/items`)
+      .set('Authorization', pharmacistAuth)
+      .send({
+        prescriptionItemId: prescription.items[0].itemId,
+        stockItemId: secondaryStockId,
+        drugId: secondaryDrugId,
+        quantity: 5,
+      })
+      .expect(201);
+
+    const completeRes = await request(app)
+      .patch(`/api/dispenses/${dispenseId}/complete`)
+      .set('Authorization', pharmacistAuth)
+      .send({ status: 'PARTIAL' });
+
+    expect(completeRes.status).toBe(200);
+    expect(completeRes.body.prescriptionStatus).toBe(PrescriptionStatus.PARTIAL);
+
+    const updatedPrescription = await prisma.prescription.findUnique({
+      where: { prescriptionId: prescription.prescriptionId },
+    });
+    expect(updatedPrescription?.status).toBe(PrescriptionStatus.PARTIAL);
+
+    const stock = await prisma.stockItem.findUnique({ where: { stockItemId: secondaryStockId } });
+    expect(stock?.qtyOnHand).toBe(secondaryInitialQty - 5);
+  });
+});


### PR DESCRIPTION
## Summary
- extend the Prisma schema, migrations, and seeding to model drugs, prescriptions, stock, and dispensing along with new pharmacy roles
- add pharmacy service logic and HTTP routes for prescribing, stock receipt, queue retrieval, and dispense completion with RBAC validation
- introduce React screens for the pharmacy queue, dispense workflow, and a doctor-facing prescribe drawer plus navigation/role updates and validation/test coverage

## Testing
- npm test *(fails: existing Jest setup cannot import the ESM server entry point)*

------
https://chatgpt.com/codex/tasks/task_e_68d417556d48832ebf1c4872f65d910a