### PR TITLE
Fix prescription status reducer type

### DIFF
--- a/src/routes/pharmacy.ts
+++ b/src/routes/pharmacy.ts
@@ -112,7 +112,7 @@ router.get(
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const raw = typeof req.query.status === 'string' ? req.query.status.split(',') : undefined;
-      const statuses = (raw ?? ['PENDING']).reduce((acc: PrescriptionStatus[], value) => {
+      const statuses = (raw ?? ['PENDING']).reduce((acc: PrescriptionStatus[], value: string) => {
         const normalized = value.trim().toUpperCase();
         if ((Object.values(PrescriptionStatus) as string[]).includes(normalized)) {
           acc.push(normalized as PrescriptionStatus);


### PR DESCRIPTION
## Summary
- add an explicit string type annotation for the reducer parameter when parsing prescription statuses

## Testing
- npx tsc --noEmit *(fails: missing type declarations such as fs, path, zod, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68d499a58f08832e8f9a7f23dda1bfad