### PR TITLE
Fix doctor role conditional check for user updates

### DIFF
--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -199,7 +199,7 @@ router.patch('/:id', async (req: Request, res: Response) => {
     } else {
       updates.doctorId = null;
     }
-  } else if (role && role !== 'Doctor') {
+  } else if (role) {
     updates.doctorId = null;
   }
 


### PR DESCRIPTION
## Summary
- simplify the non-doctor branch when updating a user's doctor assignment to avoid invalid role comparisons

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a088ee30832ebed65799cc8d5b77