### PR TITLE
Allow inventory managers access to pharmacy tools

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -112,7 +112,7 @@ function App() {
       <Route
         path="/pharmacy/queue"
         element={
-          <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech', 'ITAdmin']}>
+          <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin']}>
             <PharmacyQueue />
           </RouteGuard>
         }

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -79,7 +79,9 @@ export default function DashboardLayout({
       return user?.role === 'ITAdmin';
     }
     if (item.key === 'pharmacy') {
-      return user && ['Pharmacist', 'PharmacyTech', 'ITAdmin'].includes(user.role);
+      return (
+        user && ['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin'].includes(user.role)
+      );
     }
     return true;
   });

--- a/client/src/pages/PharmacyQueue.tsx
+++ b/client/src/pages/PharmacyQueue.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import DashboardLayout from '../components/DashboardLayout';
 import { fetchJSON } from '../api/http';
+import { useAuth } from '../context/AuthProvider';
 
 interface QueueItem {
   prescriptionId: string;
@@ -26,10 +27,12 @@ const STATUS_OPTIONS = ['PENDING', 'PARTIAL', 'DISPENSED'] as const;
 type StatusOption = (typeof STATUS_OPTIONS)[number];
 
 export default function PharmacyQueue() {
+  const { user } = useAuth();
   const [status, setStatus] = useState<StatusOption>('PENDING');
   const [data, setData] = useState<QueueItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const canDispense = user ? ['Pharmacist', 'PharmacyTech'].includes(user.role) : false;
 
   useEffect(() => {
     let cancelled = false;
@@ -125,12 +128,18 @@ export default function PharmacyQueue() {
                   ))}
                 </ul>
 
-                <Link
-                  to={`/pharmacy/dispense/${item.prescriptionId}`}
-                  className="mt-4 inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
-                >
-                  Start Dispense
-                </Link>
+                  {canDispense ? (
+                    <Link
+                      to={`/pharmacy/dispense/${item.prescriptionId}`}
+                      className="mt-4 inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+                    >
+                      Start Dispense
+                    </Link>
+                  ) : (
+                    <p className="mt-4 text-xs font-medium uppercase tracking-wide text-gray-400">
+                      Dispensing restricted to pharmacy staff
+                    </p>
+                  )}
               </article>
             ))}
           </div>

--- a/src/routes/pharmacy.ts
+++ b/src/routes/pharmacy.ts
@@ -108,7 +108,7 @@ router.post(
 
 router.get(
   '/prescriptions',
-  requireRole('Pharmacist', 'PharmacyTech', 'ITAdmin'),
+  requireRole('Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin'),
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const raw = typeof req.query.status === 'string' ? req.query.status.split(',') : undefined;


### PR DESCRIPTION
## Summary
- expose the pharmacy navigation tab to inventory managers and allow them through the pharmacy queue route guard
- let inventory managers call the pharmacy queue API while keeping dispensing actions limited to pharmacy staff
- show non-dispensing users an informational message instead of the dispense button in the pharmacy queue cards

## Testing
- npm test *(fails: existing Jest configuration cannot load ESM modules such as src/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d52e70d868832e88047a3640915849