### PR TITLE
Add password change and reset flows

### DIFF
--- a/prisma/migrations/20250215000000_add_password_reset_tokens/migration.sql
+++ b/prisma/migrations/20250215000000_add_password_reset_tokens/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "tokenId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "userId" UUID NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMPTZ NOT NULL,
+    "usedAt" TIMESTAMPTZ,
+    "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("tokenId"),
+    CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("userId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_userId_idx" ON "PasswordResetToken"("userId");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_expiresAt_idx" ON "PasswordResetToken"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,8 +198,23 @@ model User {
   doctor   Doctor?  @relation(fields: [doctorId], references: [doctorId])
   sessions Session[]
   dispenses Dispense[]
+  passwordResetTokens PasswordResetToken[]
 
   @@unique([doctorId])
+}
+
+model PasswordResetToken {
+  tokenId    String   @id @default(uuid()) @db.Uuid
+  userId     String   @db.Uuid
+  tokenHash  String
+  expiresAt  DateTime @db.Timestamptz(6)
+  usedAt     DateTime? @db.Timestamptz(6)
+  createdAt  DateTime @default(now()) @db.Timestamptz(6)
+
+  user User @relation(fields: [userId], references: [userId], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
 }
 
 model Session {

--- a/src/docs/openapi.ts
+++ b/src/docs/openapi.ts
@@ -557,6 +557,12 @@ addPath('/auth/login', 'post', {
   }
 });
 
+addPath('/auth/password/change', 'post', {
+  summary: 'Change password',
+  security: [],
+  responses: { '200': { description: 'OK' } }
+});
+
 addPath('/auth/token/refresh', 'post', {
   summary: 'Refresh access token',
   security: [],

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { Router, type Response, type NextFunction } from 'express';
 import type { Request } from 'express';
 import bcrypt from 'bcrypt';
@@ -23,6 +24,7 @@ export interface AuthRequest extends Request {
 }
 
 const prisma = new PrismaClient();
+const PASSWORD_MIN_LENGTH = 8;
 
 function parseBearerToken(header: string | undefined): string | null {
   if (!header) return null;
@@ -99,6 +101,174 @@ export function requireRole(...roles: RoleName[]) {
 }
 
 const router = Router();
+
+router.post('/password/change', requireAuth, async (req: AuthRequest, res: Response) => {
+  const body = req.body as
+    | {
+        currentPassword?: unknown;
+        newPassword?: unknown;
+      }
+    | undefined;
+
+  if (typeof body?.currentPassword !== 'string' || typeof body?.newPassword !== 'string') {
+    return res.status(400).json({ error: 'Current password and new password are required' });
+  }
+
+  const currentPassword = body.currentPassword.trim();
+  const newPassword = body.newPassword.trim();
+
+  if (newPassword.length < PASSWORD_MIN_LENGTH) {
+    return res
+      .status(400)
+      .json({ error: `New password must be at least ${PASSWORD_MIN_LENGTH} characters long` });
+  }
+
+  if (currentPassword === newPassword) {
+    return res.status(400).json({ error: 'New password must be different from the current password' });
+  }
+
+  const userId = req.user?.userId;
+  if (!userId) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { userId },
+    select: { passwordHash: true },
+  });
+
+  if (!user) {
+    return res.status(404).json({ error: 'User not found' });
+  }
+
+  let passwordValid = false;
+  try {
+    passwordValid = await bcrypt.compare(currentPassword, user.passwordHash);
+  } catch {
+    passwordValid = false;
+  }
+
+  if (!passwordValid) {
+    return res.status(400).json({ error: 'Current password is incorrect' });
+  }
+
+  const passwordHash = await bcrypt.hash(newPassword, 10);
+  const now = new Date();
+
+  await prisma.$transaction([
+    prisma.user.update({ where: { userId }, data: { passwordHash } }),
+    prisma.passwordResetToken.updateMany({
+      where: { userId, usedAt: null },
+      data: { usedAt: now },
+    }),
+  ]);
+
+  res.json({ message: 'Password updated' });
+});
+
+router.post('/password/forgot', async (req: Request, res: Response) => {
+  const body = req.body as { email?: unknown } | undefined;
+  if (typeof body?.email !== 'string' || body.email.trim().length === 0) {
+    return res.status(400).json({ error: 'A valid email address is required' });
+  }
+
+  const email = body.email.trim();
+  const normalizedEmail = email.toLowerCase();
+
+  const user = await prisma.user.findFirst({
+    where: {
+      email: { equals: normalizedEmail, mode: 'insensitive' },
+      status: 'active',
+    },
+    select: { userId: true },
+  });
+
+  const response: { message: string; resetToken?: string } = {
+    message: 'If an account exists for that email, a reset link has been sent.',
+  };
+
+  if (user) {
+    const rawToken = crypto.randomBytes(32).toString('hex');
+    const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+    const expiresAt = new Date(Date.now() + 1000 * 60 * 30);
+    const now = new Date();
+
+    await prisma.$transaction([
+      prisma.passwordResetToken.updateMany({
+        where: { userId: user.userId, usedAt: null },
+        data: { usedAt: now },
+      }),
+      prisma.passwordResetToken.create({
+        data: {
+          userId: user.userId,
+          tokenHash,
+          expiresAt,
+        },
+      }),
+    ]);
+
+    if (process.env.NODE_ENV !== 'production') {
+      response.resetToken = rawToken;
+    }
+  }
+
+  res.json(response);
+});
+
+router.post('/password/reset', async (req: Request, res: Response) => {
+  const body = req.body as { token?: unknown; password?: unknown } | undefined;
+  if (typeof body?.token !== 'string' || typeof body?.password !== 'string') {
+    return res.status(400).json({ error: 'Token and new password are required' });
+  }
+
+  const token = body.token.trim();
+  const password = body.password.trim();
+
+  if (!token) {
+    return res.status(400).json({ error: 'Token and new password are required' });
+  }
+
+  if (password.length < PASSWORD_MIN_LENGTH) {
+    return res
+      .status(400)
+      .json({ error: `Password must be at least ${PASSWORD_MIN_LENGTH} characters long` });
+  }
+
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+
+  const resetToken = await prisma.passwordResetToken.findFirst({
+    where: {
+      tokenHash,
+      usedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+  });
+
+  if (!resetToken) {
+    return res.status(400).json({ error: 'Invalid or expired reset token' });
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  const now = new Date();
+
+  await prisma.$transaction([
+    prisma.user.update({ where: { userId: resetToken.userId }, data: { passwordHash } }),
+    prisma.passwordResetToken.update({
+      where: { tokenId: resetToken.tokenId },
+      data: { usedAt: now },
+    }),
+    prisma.passwordResetToken.updateMany({
+      where: {
+        userId: resetToken.userId,
+        usedAt: null,
+        NOT: { tokenId: resetToken.tokenId },
+      },
+      data: { usedAt: now },
+    }),
+  ]);
+
+  res.json({ message: 'Password updated' });
+});
 
 router.post('/login', async (req: Request, res: Response) => {
   const body = req.body as { email?: unknown; password?: unknown } | undefined;

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -20,7 +20,6 @@ describe('POST /api/auth/login', () => {
 
   afterAll(async () => {
     await prisma.user.deleteMany({ where: { email } });
-    await prisma.$disconnect();
   });
 
   it('rejects empty credentials', async () => {
@@ -50,4 +49,120 @@ describe('POST /api/auth/login', () => {
     expect(segments[0].length).toBeGreaterThan(0);
     expect(segments[1].length).toBeGreaterThan(0);
   });
+});
+
+describe('POST /api/auth/password/change', () => {
+  const email = 'changepassword@example.com';
+  const password = 'OriginalPass123!';
+  const newPassword = 'UpdatedPass456!';
+
+  beforeAll(async () => {
+    await prisma.user.deleteMany({ where: { email } });
+    const passwordHash = await bcrypt.hash(password, 10);
+    await prisma.user.create({
+      data: { email, passwordHash, role: 'Doctor', status: 'active' },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.user.deleteMany({ where: { email } });
+  });
+
+  it('requires the current password to match', async () => {
+    const loginRes = await request(app).post('/api/auth/login').send({ email, password });
+    expect(loginRes.status).toBe(200);
+
+    const token = loginRes.body.accessToken as string;
+    const res = await request(app)
+      .post('/api/auth/password/change')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'WrongPass!', newPassword });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Current password is incorrect');
+  });
+
+  it('allows changing the password with the correct current password', async () => {
+    const loginRes = await request(app).post('/api/auth/login').send({ email, password });
+    expect(loginRes.status).toBe(200);
+    const token = loginRes.body.accessToken as string;
+
+    const res = await request(app)
+      .post('/api/auth/password/change')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: password, newPassword });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Password updated');
+
+    const relogin = await request(app).post('/api/auth/login').send({ email, password: newPassword });
+    expect(relogin.status).toBe(200);
+  });
+});
+
+describe('Password reset flow', () => {
+  const email = 'resetuser@example.com';
+  const password = 'ResetPass123!';
+  const newPassword = 'ResetPass789!';
+
+  beforeAll(async () => {
+    await prisma.passwordResetToken.deleteMany({ where: { user: { email } } });
+    await prisma.user.deleteMany({ where: { email } });
+    const passwordHash = await bcrypt.hash(password, 10);
+    await prisma.user.create({
+      data: { email, passwordHash, role: 'Doctor', status: 'active' },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.passwordResetToken.deleteMany({ where: { user: { email } } });
+    await prisma.user.deleteMany({ where: { email } });
+  });
+
+  it('issues a reset token and updates the password', async () => {
+    const forgotRes = await request(app)
+      .post('/api/auth/password/forgot')
+      .send({ email });
+
+    expect(forgotRes.status).toBe(200);
+    expect(forgotRes.body.message).toBe('If an account exists for that email, a reset link has been sent.');
+    expect(typeof forgotRes.body.resetToken).toBe('string');
+
+    const token = forgotRes.body.resetToken as string;
+
+    const tooShort = await request(app)
+      .post('/api/auth/password/reset')
+      .send({ token, password: 'short' });
+    expect(tooShort.status).toBe(400);
+
+    const resetRes = await request(app)
+      .post('/api/auth/password/reset')
+      .send({ token, password: newPassword });
+
+    expect(resetRes.status).toBe(200);
+    expect(resetRes.body.message).toBe('Password updated');
+
+    const loginRes = await request(app).post('/api/auth/login').send({ email, password: newPassword });
+    expect(loginRes.status).toBe(200);
+
+    const reuseRes = await request(app)
+      .post('/api/auth/password/reset')
+      .send({ token, password: `${newPassword}!` });
+    expect(reuseRes.status).toBe(400);
+    expect(reuseRes.body.error).toBe('Invalid or expired reset token');
+  });
+
+  it('does not leak whether the email exists', async () => {
+    const res = await request(app)
+      .post('/api/auth/password/forgot')
+      .send({ email: 'unknown@example.com' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.resetToken).toBeUndefined();
+    expect(res.body.message).toBe('If an account exists for that email, a reset link has been sent.');
+  });
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
 });


### PR DESCRIPTION
## Summary
- add a Prisma model and migration for storing password reset tokens
- implement password change, forgot, and reset endpoints in the auth module and document the change route
- extend auth integration tests to cover password change and reset flows

## Testing
- npm test *(fails: Jest cannot load ESM server.js under the current configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b51e1bf0832e957c2789c7a972ae