### PR TITLE
Improve mobile and tablet responsiveness

### DIFF
--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -138,7 +138,7 @@ export default function DashboardLayout({
 
   return (
     <div className="flex min-h-screen bg-gray-50">
-      <aside className="hidden w-72 flex-col border-r border-gray-200 bg-white px-6 py-8 shadow-sm md:flex">
+      <aside className="hidden w-72 flex-col border-r border-gray-200 bg-white px-6 py-8 shadow-sm md:flex lg:w-80">
         <div className="text-lg font-semibold text-blue-600">{displayName}</div>
         <nav className="mt-8 space-y-1">
           <NavigationLinks />
@@ -162,7 +162,7 @@ export default function DashboardLayout({
             aria-label={t('Close navigation')}
             onClick={() => setIsMobileNavOpen(false)}
           />
-          <div className="relative ml-auto flex h-full w-72 max-w-full flex-col bg-white px-6 py-6 shadow-xl">
+          <div className="relative ml-auto flex h-full w-full max-w-xs flex-col bg-white px-6 py-6 shadow-xl">
             <div className="flex items-center justify-between gap-3">
               <span className="text-lg font-semibold text-blue-600">{displayName}</span>
               <button
@@ -198,8 +198,8 @@ export default function DashboardLayout({
       )}
 
       <div className="flex flex-1 flex-col">
-        <header className="border-b border-gray-200 bg-white">
-          <div className="flex flex-col gap-6 px-4 py-4 sm:px-6 sm:py-6">
+        <header className="sticky top-0 z-30 border-b border-gray-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80">
+          <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
               <div className="flex items-center justify-between gap-3 md:justify-start">
                 <Link to="/" className="flex items-center gap-3 text-gray-900">
@@ -248,7 +248,9 @@ export default function DashboardLayout({
           </div>
         </header>
 
-        <main className="flex-1 px-4 py-6 sm:px-6 sm:py-8">{children}</main>
+        <main className="flex-1 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+          <div className="mx-auto w-full max-w-7xl">{children}</div>
+        </main>
       </div>
     </div>
   );

--- a/client/src/components/PageLayout.tsx
+++ b/client/src/components/PageLayout.tsx
@@ -7,8 +7,10 @@ interface PageLayoutProps {
 
 export default function PageLayout({ children, maxWidth = 'max-w-2xl' }: PageLayoutProps) {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
-      <div className={`w-full ${maxWidth} rounded-2xl bg-white p-6 shadow sm:p-8`}>{children}</div>
+    <div className="flex min-h-screen flex-col bg-gray-100">
+      <div className="flex flex-1 items-start justify-center px-4 py-6 sm:px-6 sm:py-10 lg:items-center lg:px-8">
+        <div className={`w-full ${maxWidth} rounded-2xl bg-white p-6 shadow-sm sm:p-8 lg:p-10`}>{children}</div>
+      </div>
     </div>
   );
 }

--- a/client/src/components/PatientSearch.tsx
+++ b/client/src/components/PatientSearch.tsx
@@ -99,7 +99,7 @@ export default function PatientSearch() {
       activeItem="patients"
       headerChildren={headerContent}
     >
-      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[2fr_1fr]">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]">
         <section className="rounded-2xl bg-white p-6 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>

--- a/client/src/pages/AddVisit.tsx
+++ b/client/src/pages/AddVisit.tsx
@@ -153,7 +153,7 @@ export default function AddVisit() {
           {t(patientError)}
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[3fr_2fr]">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr]">
           <div className="space-y-6">
             <section className="rounded-2xl bg-white p-6 shadow-sm">
               <div className="flex items-start justify-between gap-4">

--- a/client/src/pages/AppointmentDetail.tsx
+++ b/client/src/pages/AppointmentDetail.tsx
@@ -683,7 +683,7 @@ export default function AppointmentDetail() {
           {error}
         </div>
       ) : appointment ? (
-        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[3fr_2fr]">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr]">
           <div className="space-y-6">
             <section className="rounded-2xl bg-white p-6 shadow-sm">
               <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">

--- a/client/src/pages/AppointmentForm.tsx
+++ b/client/src/pages/AppointmentForm.tsx
@@ -507,7 +507,7 @@ export default function AppointmentForm() {
           Loading appointment details...
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[3fr_2fr]">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr]">
           <form onSubmit={handleSubmit} className="space-y-6">
             <section className="rounded-2xl bg-white p-6 shadow-sm">
               <div className="flex items-start justify-between gap-4">

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -191,7 +191,7 @@ function ITAdminDashboard() {
       activeItem="dashboard"
     >
       <div className="space-y-6">
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           <StatsCard
             title={t('Staff Accounts')}
             value={userStats.total}
@@ -223,7 +223,7 @@ function ITAdminDashboard() {
           />
         </div>
 
-        <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3">
           <div className="rounded-2xl bg-white p-6 shadow-sm xl:col-span-2">
             <div className="flex items-center justify-between">
               <div>
@@ -560,7 +560,7 @@ function TeamDashboard({ role }: { role?: string }) {
       }
       headerChildren={headerSearch}
     >
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         <div className="flex flex-col rounded-2xl bg-white p-6 shadow-sm">
           <div className="flex items-start gap-4">
             <div className="rounded-xl bg-blue-100 p-3 text-blue-600">

--- a/client/src/pages/PharmacyInventory.tsx
+++ b/client/src/pages/PharmacyInventory.tsx
@@ -452,7 +452,7 @@ export default function PharmacyInventory() {
                 </div>
               ) : (
                 <form className="mt-4 space-y-4" onSubmit={handleAdjust}>
-                  <div className="overflow-hidden rounded-xl border border-gray-200">
+                  <div className="overflow-x-auto rounded-xl border border-gray-200">
                     <table className="min-w-full divide-y divide-gray-200 text-sm">
                       <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
                         <tr>

--- a/client/src/pages/PharmacyQueue.tsx
+++ b/client/src/pages/PharmacyQueue.tsx
@@ -113,7 +113,7 @@ export default function PharmacyQueue() {
             Nothing in the queue for this status.
           </div>
         ) : (
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {data.map((item) => (
               <article key={item.prescriptionId} className="flex h-full flex-col rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
                 <div className="flex items-start justify-between gap-3">

--- a/client/src/pages/RegisterPatient.tsx
+++ b/client/src/pages/RegisterPatient.tsx
@@ -61,7 +61,7 @@ export default function RegisterPatient() {
       activeItem="patients"
       headerChildren={headerActions}
     >
-      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[3fr_2fr]">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr]">
         <form onSubmit={handleSubmit} className="space-y-6">
           <section className="rounded-2xl bg-white p-6 shadow-sm">
             <div className="flex items-start justify-between gap-4">

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -94,7 +94,7 @@ export default function Reports() {
       {data && (
         <div className="space-y-10">
           <section>
-            <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-5">
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5">
               {metrics.map((metric) => (
                 <MetricCard key={metric.label} {...metric} />
               ))}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -404,7 +404,7 @@ export default function Settings() {
       headerChildren={headerStatus}
     >
       <div className="space-y-6">
-        <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <section className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
           <div className="flex flex-col rounded-2xl bg-white p-5 shadow-sm">
             <div className="flex items-center gap-3">
               <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-50 text-blue-600">
@@ -484,7 +484,7 @@ export default function Settings() {
           </div>
         </section>
 
-        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[2fr_1.1fr]">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1.1fr]">
           <section className="space-y-6">
             <div className="rounded-2xl bg-white p-6 shadow-sm">
               <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -1,3 +1,17 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    @apply h-full scroll-smooth;
+  }
+
+  body {
+    @apply min-h-full bg-gray-50 text-gray-900 antialiased;
+  }
+
+  #root {
+    @apply min-h-full;
+  }
+}


### PR DESCRIPTION
## Summary
- update the shared page and dashboard layouts with centered containers, sticky headers, and improved mobile navigation widths
- tune grid breakpoints and table overflow handling across patient, appointment, pharmacy, and reports pages for tablet friendliness
- add base Tailwind resets for smoother scrolling and consistent background/text styles on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7bd652e38832e9056b9525571b07a