### PR TITLE
Fix pharmacy router base path

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,7 @@ apiRouter.use('/auth', authRouter);
 apiRouter.use('/appointments', appointmentsRouter);
 apiRouter.use('/users', usersRouter);
 apiRouter.use('/reports', reportsRouter);
-apiRouter.use(pharmacyRouter);
+apiRouter.use('/pharmacy', pharmacyRouter);
 apiRouter.use(docsRouter);
 
 export default apiRouter;


### PR DESCRIPTION
## Summary
- mount the pharmacy router under the `/pharmacy` prefix so its endpoints are available at the expected paths

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7bf7981a8832e9131e039f98ff92c