### PR TITLE
Fix expiry date format when recording stock

### DIFF
--- a/client/src/pages/PharmacyInventory.tsx
+++ b/client/src/pages/PharmacyInventory.tsx
@@ -154,7 +154,10 @@ export default function PharmacyInventory() {
       payload.batchNo = receiveForm.batchNo.trim();
     }
     if (receiveForm.expiryDate) {
-      payload.expiryDate = receiveForm.expiryDate;
+      const expiry = new Date(`${receiveForm.expiryDate}T00:00:00Z`);
+      if (!Number.isNaN(expiry.getTime())) {
+        payload.expiryDate = expiry.toISOString();
+      }
     }
     if (receiveForm.unitCost) {
       const cost = Number.parseFloat(receiveForm.unitCost);


### PR DESCRIPTION
## Summary
- convert the receive stock expiry date into an ISO timestamp before sending to the API to satisfy server-side validation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7c27b8f5c832eb9bdcc9fbedf0dfe