### PR TITLE
Add drug allergy capture to patient registration

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -15,6 +15,7 @@ export interface Patient {
   insurance: string | null;
   gender?: string | null;
   contact?: string | null;
+  drugAllergies?: string | null;
 }
 
 export interface Doctor {
@@ -201,6 +202,7 @@ export interface CreatePatientPayload {
   name: string;
   dob: string;
   insurance: string;
+  drugAllergies?: string;
 }
 
 export async function createPatient(payload: CreatePatientPayload): Promise<Patient> {

--- a/client/src/i18n/translations.csv
+++ b/client/src/i18n/translations.csv
@@ -156,3 +156,7 @@ Follow up on {count} appointments past their start time.,Follow up on {count} ap
 {count} patients waiting to check in.,{count} patients waiting to check in.,{count} patients waiting to check in.
 No patients have checked in yet.,No patients have checked in yet.,No patients have checked in yet.
 No pending tasks for today.,No pending tasks for today.,No pending tasks for today.
+Drug allergies,Drug allergies,ဆေးအလွန်မတုံ့ပြန်မှုများ
+No known allergies,No known allergies,မသိရှိရသေးသော အလွန်မတုံ့ပြန်မှုများ
+Document medications to avoid during care.,Document medications to avoid during care.,ကုသမှုတွင် မသုံးသင့်သော ဆေးဝါးများကို မှတ်တမ်းတင်ပါ။
+e.g. Penicillin, Ibuprofen,e.g. Penicillin, Ibuprofen,ဥပမာ- ပီနစ်ဆီလင်း၊ အိုင်ဘူပရိုဖင်

--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -413,6 +413,7 @@ export default function PatientDetail() {
 
   const contact = patient?.contact?.trim() || t('Not provided');
   const coverage = patient?.insurance?.trim() || t('Self-pay');
+  const allergies = patient?.drugAllergies?.trim() || t('No known allergies');
   const gender = formatGenderValue(patient?.gender);
   const age = patient ? calculateAge(patient.dob) : null;
   const lastVisit = patient?.visits?.[0] ?? null;
@@ -465,6 +466,7 @@ export default function PatientDetail() {
                 { label: t('Date of Birth'), value: formatDateValue(patient.dob) },
                 { label: t('Age'), value: age !== null ? t('{count} yrs', { count: age }) : '—' },
                 { label: t('Insurance'), value: coverage },
+                { label: t('Drug allergies'), value: allergies },
                 { label: t('Gender'), value: gender },
               ].map((stat) => (
                 <div

--- a/client/src/pages/RegisterPatient.tsx
+++ b/client/src/pages/RegisterPatient.tsx
@@ -9,6 +9,7 @@ export default function RegisterPatient() {
   const [name, setName] = useState('');
   const [dob, setDob] = useState('');
   const [insurance, setInsurance] = useState('');
+  const [drugAllergies, setDrugAllergies] = useState('');
   const [saving, setSaving] = useState(false);
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -32,7 +33,7 @@ export default function RegisterPatient() {
     e.preventDefault();
     setSaving(true);
     try {
-      const patient = await createPatient({ name, dob, insurance });
+      const patient = await createPatient({ name, dob, insurance, drugAllergies: drugAllergies.trim() || undefined });
       navigate(`/patients/${patient.patientId}`);
     } catch (err) {
       console.error(err);
@@ -122,6 +123,21 @@ export default function RegisterPatient() {
                 />
                 <p className="mt-1 text-xs text-gray-500">{t('Include private or public coverage information.')}</p>
               </div>
+
+              <div className="md:col-span-2">
+                <label className="block text-sm font-medium text-gray-700" htmlFor="patient-allergies">
+                  {t('Drug allergies')}
+                </label>
+                <textarea
+                  id="patient-allergies"
+                  value={drugAllergies}
+                  onChange={(e) => setDrugAllergies(e.target.value)}
+                  rows={3}
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                  placeholder={t('e.g. Penicillin, Ibuprofen')}
+                />
+                <p className="mt-1 text-xs text-gray-500">{t('Document medications to avoid during care.')}</p>
+              </div>
             </div>
           </section>
 
@@ -172,6 +188,10 @@ export default function RegisterPatient() {
               <div className="flex items-start justify-between gap-3">
                 <dt className="font-medium text-gray-600">{t('Insurance')}</dt>
                 <dd className="text-right text-gray-900">{insurance || t('Not captured yet')}</dd>
+              </div>
+              <div className="flex items-start justify-between gap-3">
+                <dt className="font-medium text-gray-600">{t('Drug allergies')}</dt>
+                <dd className="text-right text-gray-900">{drugAllergies || t('No known allergies')}</dd>
               </div>
             </dl>
           </div>

--- a/client/src/pages/VisitDetail.tsx
+++ b/client/src/pages/VisitDetail.tsx
@@ -157,6 +157,7 @@ export default function VisitDetail() {
   const gender = formatGender(patient?.gender);
   const contact = patient?.contact?.trim() || 'Not provided';
   const age = patient ? calculateAge(patient.dob) : null;
+  const allergies = patient?.drugAllergies?.trim() || 'No known allergies';
 
   const vitalsSource = visit?.observations.find(
     (observation) =>
@@ -265,6 +266,10 @@ export default function VisitDetail() {
                   <div className="flex items-center justify-between gap-4">
                     <dt className="text-gray-500">Insurance</dt>
                     <dd className="font-semibold text-gray-900">{coverage}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-gray-500">Drug allergies</dt>
+                    <dd className="text-right font-semibold text-gray-900">{allergies}</dd>
                   </div>
                   <div className="flex items-center justify-between gap-4">
                     <dt className="text-gray-500">Contact</dt>

--- a/prisma/migrations/20240518000000_add_patient_drug_allergies/migration.sql
+++ b/prisma/migrations/20240518000000_add_patient_drug_allergies/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Patient" ADD COLUMN "drugAllergies" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,7 @@ model Patient {
   gender       Gender
   contact      String?
   insurance    String?
+  drugAllergies String?
   createdAt    DateTime @default(now()) @db.Timestamptz(6)
   updatedAt    DateTime @default(now()) @updatedAt @db.Timestamptz(6)
 

--- a/src/docs/openapi.ts
+++ b/src/docs/openapi.ts
@@ -102,7 +102,8 @@ const openapi: any = {
           dob: { type: 'string', format: 'date' },
           gender: { type: 'string', enum: ['M', 'F'] },
           contact: { type: 'string', nullable: true },
-          insurance: { type: 'string', nullable: true }
+          insurance: { type: 'string', nullable: true },
+          drugAllergies: { type: 'string', nullable: true }
         }
       },
       Doctor: {
@@ -660,6 +661,7 @@ addPath('/patients', 'post', {
             name: { type: 'string' },
             dob: { type: 'string', format: 'date' },
             insurance: { type: 'string' },
+            drugAllergies: { type: 'string' }
           },
         },
       },

--- a/tests/patients.test.ts
+++ b/tests/patients.test.ts
@@ -10,10 +10,26 @@ beforeAll(async () => {
   await prisma.user.create({ data: { email: 'doc@example.com', passwordHash: 'x', role: 'Doctor' } });
   const doctor = await prisma.doctor.create({ data: { name: 'Dr. Who', department: 'General' } });
   const patient = await prisma.patient.create({
-    data: { name: 'John Doe', dob: new Date('1980-01-01'), gender: 'M', contact: '5551234', insurance: 'Aetna' },
+    data: {
+      name: 'John Doe',
+      dob: new Date('1980-01-01'),
+      gender: 'M',
+      contact: '5551234',
+      insurance: 'Aetna',
+      drugAllergies: 'Penicillin',
+    },
   });
   patientId = patient.patientId;
-  await prisma.patient.create({ data: { name: 'Jane Smith', dob: new Date('1990-01-01'), gender: 'F', contact: '5555678', insurance: 'Aetna' } });
+  await prisma.patient.create({
+    data: {
+      name: 'Jane Smith',
+      dob: new Date('1990-01-01'),
+      gender: 'F',
+      contact: '5555678',
+      insurance: 'Aetna',
+      drugAllergies: 'Sulfa',
+    },
+  });
   const visit1 = await prisma.visit.create({ data: { patientId: patient.patientId, doctorId: doctor.doctorId, visitDate: new Date('2023-01-01'), department: 'Cardiology', reason: 'checkup' } });
   const visit2 = await prisma.visit.create({ data: { patientId: patient.patientId, doctorId: doctor.doctorId, visitDate: new Date('2023-02-01'), department: 'Endocrinology', reason: 'follow-up' } });
   await prisma.diagnosis.create({ data: { visitId: visit2.visitId, diagnosis: 'Diabetes' } });
@@ -74,8 +90,10 @@ describe('POST /api/patients', () => {
       name: 'Alice Jones',
       dob: '2001-01-01',
       insurance: 'Aetna',
+      drugAllergies: 'Ibuprofen',
     });
     expect(res.status).toBe(201);
     expect(res.body.name).toBe('Alice Jones');
+    expect(res.body.drugAllergies).toBe('Ibuprofen');
   });
 });


### PR DESCRIPTION
## Summary
- add a drug allergies field to the patient registration workflow, preview card, and translations
- persist allergy data by extending the patient schema, API contract, migration, and automated tests
- surface recorded drug allergies in patient and visit detail pages and client types

## Testing
- npm test -- --runTestsByPath tests/patients.test.ts *(fails: Must use import to load ES Module: /workspace/EMR/src/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fed3f148832ea25b990d68078dfe