### PR TITLE
Add OpenAI-powered invoice scanning for pharmacy workflows

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -104,6 +104,37 @@ export interface AdjustStockItemPayload {
   reason?: string;
 }
 
+export interface InvoiceScanLineItem {
+  brandName?: string | null;
+  genericName?: string | null;
+  form?: string | null;
+  strength?: string | null;
+  packageDescription?: string | null;
+  quantity?: number | null;
+  unitCost?: number | null;
+  batchNumber?: string | null;
+  expiryDate?: string | null;
+  notes?: string | null;
+  suggestedLocation?: string | null;
+}
+
+export interface InvoiceScanMetadata {
+  vendor?: string | null;
+  invoiceNumber?: string | null;
+  invoiceDate?: string | null;
+  currency?: string | null;
+  subtotal?: number | null;
+  total?: number | null;
+  destination?: string | null;
+}
+
+export interface InvoiceScanResult {
+  metadata: InvoiceScanMetadata;
+  lineItems: InvoiceScanLineItem[];
+  warnings: string[];
+  rawText?: string | null;
+}
+
 export interface LabResult {
   testName: string;
   resultValue: number | null;
@@ -313,6 +344,20 @@ export async function adjustStockLevels(adjustments: AdjustStockItemPayload[]) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ adjustments }),
   });
+}
+
+export async function scanInvoiceForInventory(file: File): Promise<InvoiceScanResult> {
+  const formData = new FormData();
+  formData.append('invoice', file);
+  const response = await fetchJSON('/pharmacy/inventory/invoice/scan', {
+    method: 'POST',
+    body: formData,
+  });
+  return ((response as { data?: InvoiceScanResult }).data) ?? {
+    metadata: {},
+    lineItems: [],
+    warnings: ['Invoice scan returned no results.'],
+  };
 }
 
 export interface CreateVisitPayload {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "express-rate-limit": "^7",
         "helmet": "^7",
         "morgan": "^1",
+        "multer": "^2.0.0",
+        "openai": "^4.77.3",
         "prisma": "^6.15.0",
         "zod": "^3"
       },
@@ -23,6 +25,7 @@
         "@types/express": "^4",
         "@types/jest": "^29",
         "@types/morgan": "^1",
+        "@types/multer": "^1.4.12",
         "@types/node": "^20.19.13",
         "@types/supertest": "^2",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
@@ -2141,14 +2144,33 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
       "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/qs": {
@@ -2490,6 +2512,18 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "license": "ISC"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2549,6 +2583,18 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2636,6 +2682,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/aproba": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
@@ -2687,7 +2739,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-jest": {
@@ -2989,8 +3040,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -3324,7 +3385,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -3348,6 +3408,21 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/concurrently": {
       "version": "9.2.1",
@@ -3576,7 +3651,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -3804,7 +3878,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4123,6 +4196,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -4458,7 +4540,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4469,6 +4550,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/formidable": {
@@ -4839,7 +4939,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4922,6 +5021,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -6139,7 +6247,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6246,6 +6353,36 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/multer/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6274,6 +6411,26 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -6457,6 +6614,51 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.127",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.127.tgz",
+      "integrity": "sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -7392,6 +7594,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7935,6 +8145,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -7967,7 +8183,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -8076,6 +8291,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -8176,7 +8400,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29",
+    "@types/multer": "^1.4.12",
     "@types/node": "^20.19.13",
     "@types/supertest": "^2",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
@@ -57,6 +58,8 @@
     "express-rate-limit": "^7",
     "helmet": "^7",
     "morgan": "^1",
+    "openai": "^4.77.3",
+    "multer": "^2.0.0",
     "prisma": "^6.15.0",
     "zod": "^3"
   }

--- a/src/services/invoiceScanner.ts
+++ b/src/services/invoiceScanner.ts
@@ -1,0 +1,284 @@
+import OpenAI from 'openai';
+
+export interface InvoiceScanLineItem {
+  brandName?: string | null;
+  genericName?: string | null;
+  form?: string | null;
+  strength?: string | null;
+  packageDescription?: string | null;
+  quantity?: number | null;
+  unitCost?: number | null;
+  batchNumber?: string | null;
+  expiryDate?: string | null;
+  notes?: string | null;
+  suggestedLocation?: string | null;
+}
+
+export interface InvoiceScanMetadata {
+  vendor?: string | null;
+  invoiceNumber?: string | null;
+  invoiceDate?: string | null;
+  currency?: string | null;
+  subtotal?: number | null;
+  total?: number | null;
+  destination?: string | null;
+}
+
+export interface InvoiceScanResult {
+  metadata: InvoiceScanMetadata;
+  lineItems: InvoiceScanLineItem[];
+  warnings: string[];
+  rawText?: string | null;
+}
+
+export class InvoiceScanError extends Error {
+  statusCode?: number;
+  details?: unknown;
+
+  constructor(message: string, options?: { statusCode?: number; cause?: unknown; details?: unknown }) {
+    super(message);
+    this.name = 'InvoiceScanError';
+    this.statusCode = options?.statusCode;
+    this.details = options?.details;
+    if (options?.cause) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+const DEFAULT_MODEL = 'gpt-4o-mini';
+let cachedClient: OpenAI | null = null;
+
+function getClient() {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new InvoiceScanError('OpenAI API key is not configured. Set OPENAI_API_KEY to enable invoice scanning.', {
+      statusCode: 503,
+    });
+  }
+  if (!cachedClient) {
+    cachedClient = new OpenAI({ apiKey });
+  }
+  return cachedClient;
+}
+
+function ensureJsonObject(content: string) {
+  const firstBrace = content.indexOf('{');
+  const lastBrace = content.lastIndexOf('}');
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    throw new InvoiceScanError('Unable to parse invoice response from OpenAI.', {
+      statusCode: 502,
+    });
+  }
+  const jsonSlice = content.slice(firstBrace, lastBrace + 1);
+  try {
+    return JSON.parse(jsonSlice);
+  } catch (error) {
+    throw new InvoiceScanError('Invoice parsing returned invalid JSON data.', {
+      statusCode: 502,
+      cause: error,
+    });
+  }
+}
+
+function normalizeNumber(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const cleaned = value.replace(/[^0-9.,-]/g, '').replace(/,/g, '');
+    const parsed = Number.parseFloat(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length ? trimmed : null;
+  }
+  return null;
+}
+
+function normalizeDate(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString().slice(0, 10);
+}
+
+function buildSchema() {
+  return {
+    name: 'pharmacy_invoice_extraction',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['lineItems'],
+      properties: {
+        rawText: { type: 'string', description: 'Full transcription of the invoice if helpful', nullable: true },
+        warnings: {
+          type: 'array',
+          description: 'Any issues or ambiguities detected while reading the invoice.',
+          items: { type: 'string' },
+        },
+        metadata: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            vendor: { type: 'string', nullable: true },
+            invoiceNumber: { type: 'string', nullable: true },
+            invoiceDate: {
+              type: 'string',
+              nullable: true,
+              description: 'ISO 8601 date (YYYY-MM-DD) for the invoice',
+            },
+            currency: { type: 'string', nullable: true },
+            subtotal: { type: 'number', nullable: true },
+            total: { type: 'number', nullable: true },
+            destination: {
+              type: 'string',
+              nullable: true,
+              description: 'Receiving location or department if present on the invoice',
+            },
+          },
+          required: [],
+        },
+        lineItems: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              brandName: { type: 'string', nullable: true },
+              genericName: { type: 'string', nullable: true },
+              form: { type: 'string', nullable: true },
+              strength: { type: 'string', nullable: true },
+              packageDescription: { type: 'string', nullable: true },
+              quantity: { type: 'number', nullable: true },
+              unitCost: { type: 'number', nullable: true },
+              batchNumber: { type: 'string', nullable: true },
+              expiryDate: {
+                type: 'string',
+                nullable: true,
+                description: 'ISO 8601 date (YYYY-MM-DD) representing the expiration date',
+              },
+              notes: { type: 'string', nullable: true },
+              suggestedLocation: {
+                type: 'string',
+                nullable: true,
+                description: 'Storage or destination hinted at by the invoice line if provided',
+              },
+            },
+            required: [],
+          },
+        },
+      },
+    },
+    strict: true,
+  } as const;
+}
+
+export async function scanInvoice(buffer: Buffer, mimeType?: string | null): Promise<InvoiceScanResult> {
+  if (!buffer.length) {
+    throw new InvoiceScanError('Invoice file is empty.', { statusCode: 400 });
+  }
+
+  const client = getClient();
+  const model = process.env.OPENAI_INVOICE_MODEL || DEFAULT_MODEL;
+  const base64 = buffer.toString('base64');
+  const imageUrl = `data:${mimeType || 'application/octet-stream'};base64,${base64}`;
+
+  try {
+    const response = await client.chat.completions.create({
+      model,
+      temperature: 0,
+      response_format: { type: 'json_schema', json_schema: buildSchema() },
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are an assistant that extracts structured pharmacy inventory data from supplier invoices. ' +
+            'Return JSON that matches the provided schema. ' +
+            'Capture medication names, strengths, forms, quantities, batch or lot numbers, expiration dates, and unit costs when available. ' +
+            'If values are not provided, use null.',
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text:
+                'Read this invoice and summarize each medication line. ' +
+                'Please keep numbers as digits and use ISO 8601 dates (YYYY-MM-DD).',
+            },
+            {
+              type: 'image_url',
+              image_url: imageUrl,
+            },
+          ],
+        },
+      ],
+    });
+
+    const message = response.choices?.[0]?.message?.content;
+    if (!message) {
+      throw new InvoiceScanError('OpenAI returned an empty response for the invoice.', {
+        statusCode: 502,
+      });
+    }
+
+    const textContent = Array.isArray(message)
+      ? message
+          .map((part) => ('text' in part ? part.text : typeof part === 'string' ? part : ''))
+          .join('')
+      : message;
+
+    const parsed = ensureJsonObject(textContent);
+    const rawWarnings = Array.isArray(parsed.warnings) ? parsed.warnings : [];
+    const metadata = parsed.metadata ?? {};
+    const normalizedMetadata: InvoiceScanMetadata = {
+      vendor: normalizeString(metadata.vendor),
+      invoiceNumber: normalizeString(metadata.invoiceNumber),
+      invoiceDate: normalizeDate(metadata.invoiceDate),
+      currency: normalizeString(metadata.currency),
+      subtotal: normalizeNumber(metadata.subtotal),
+      total: normalizeNumber(metadata.total),
+      destination: normalizeString(metadata.destination),
+    };
+
+    const lineItemsSource = Array.isArray(parsed.lineItems) ? parsed.lineItems : [];
+    const lineItems: InvoiceScanLineItem[] = lineItemsSource.map((item: Record<string, unknown>) => ({
+      brandName: normalizeString(item.brandName),
+      genericName: normalizeString(item.genericName),
+      form: normalizeString(item.form),
+      strength: normalizeString(item.strength),
+      packageDescription: normalizeString(item.packageDescription),
+      quantity: normalizeNumber(item.quantity),
+      unitCost: normalizeNumber(item.unitCost),
+      batchNumber: normalizeString(item.batchNumber),
+      expiryDate: normalizeDate(item.expiryDate),
+      notes: normalizeString(item.notes),
+      suggestedLocation: normalizeString(item.suggestedLocation),
+    }));
+
+    return {
+      metadata: normalizedMetadata,
+      lineItems,
+      warnings: rawWarnings.map((warning: unknown) => normalizeString(warning) || 'Unspecified issue detected during parsing.'),
+      rawText: normalizeString(parsed.rawText),
+    };
+  } catch (error) {
+    if (error instanceof InvoiceScanError) {
+      throw error;
+    }
+    throw new InvoiceScanError('Unable to analyze the invoice automatically. Please enter details manually.', {
+      statusCode: 502,
+      cause: error,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add an OpenAI-backed invoice scanning service and authenticated API endpoint for pharmacy staff
- wire up invoice upload widgets on the add medication and receive stock screens to prefill fields and highlight missing data
- expose shared client helpers and types for invoice extraction responses

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d805f27aa8832eb965fb8d0c88021a