### PR TITLE
feat: add billing and invoicing module

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,9 @@ import PharmacyQueue from './pages/PharmacyQueue';
 import DispenseDetail from './pages/DispenseDetail';
 import PharmacyInventory from './pages/PharmacyInventory';
 import AddDrug from './pages/AddDrug';
+import VisitBilling from './pages/VisitBilling';
+import PosList from './pages/PosList';
+import SettingsServices from './pages/SettingsServices';
 import './styles/App.css';
 
 function App() {
@@ -136,6 +139,22 @@ function App() {
         }
       />
       <Route
+        path="/billing/visit/:visitId"
+        element={
+          <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'Doctor', 'Pharmacist']}>
+            <VisitBilling />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/billing/pos"
+        element={
+          <RouteGuard allowedRoles={['Cashier', 'ITAdmin']}>
+            <PosList />
+          </RouteGuard>
+        }
+      />
+      <Route
         path="/pharmacy/dispense/:prescriptionId"
         element={
           <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech']}>
@@ -148,6 +167,14 @@ function App() {
         element={
           <RouteGuard allowedRoles={['ITAdmin']}>
             <Settings />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/settings/services"
+        element={
+          <RouteGuard allowedRoles={['ITAdmin']}>
+            <SettingsServices />
           </RouteGuard>
         }
       />

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -3,6 +3,7 @@ import { fetchJSON } from './http';
 export type Role =
   | 'Doctor'
   | 'AdminAssistant'
+  | 'Cashier'
   | 'ITAdmin'
   | 'Pharmacist'
   | 'PharmacyTech'

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -21,6 +21,7 @@ type NavigationKey =
   | 'dashboard'
   | 'patients'
   | 'appointments'
+  | 'billing'
   | 'pharmacy'
   | 'reports'
   | 'settings';
@@ -36,6 +37,7 @@ const navigation: NavigationItem[] = [
   { key: 'dashboard', name: 'Dashboard', icon: DashboardIcon, to: '/' },
   { key: 'patients', name: 'Patients', icon: PatientsIcon, to: '/patients' },
   { key: 'appointments', name: 'Appointments', icon: CalendarIcon, to: '/appointments' },
+  { key: 'billing', name: 'Billing', icon: ReportsIcon, to: '/billing/pos' },
   { key: 'pharmacy', name: 'Pharmacy', icon: PharmacyIcon, to: '/pharmacy/queue' },
   { key: 'reports', name: 'Reports', icon: ReportsIcon, to: '/reports' },
   { key: 'settings', name: 'Settings', icon: SettingsIcon, to: '/settings' },
@@ -77,6 +79,9 @@ export default function DashboardLayout({
   const navItems = navigation.filter((item) => {
     if (item.key === 'settings') {
       return user?.role === 'ITAdmin';
+    }
+    if (item.key === 'billing') {
+      return user && ['Cashier', 'ITAdmin'].includes(user.role);
     }
     if (item.key === 'pharmacy') {
       return (
@@ -261,6 +266,7 @@ export type { NavigationKey };
 const ROLE_LABELS: Record<string, string> = {
   Doctor: 'Doctor',
   AdminAssistant: 'Administrative Assistant',
+  Cashier: 'Cashier',
   ITAdmin: 'IT Administrator',
   Pharmacist: 'Pharmacist',
   PharmacyTech: 'Pharmacy Technician',

--- a/client/src/pages/PosList.tsx
+++ b/client/src/pages/PosList.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+import { fetchJSON } from '../api/http';
+
+type InvoiceSummary = {
+  invoiceId: string;
+  visitId: string;
+  patientId: string;
+  status: string;
+  amountDue: string;
+  grandTotal: string;
+  invoiceNo: string;
+  Patient?: {
+    name: string;
+  } | null;
+};
+
+function formatMoney(value: string) {
+  const numeric = Number.parseFloat(value);
+  if (Number.isNaN(numeric)) {
+    return value;
+  }
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'MMK' }).format(numeric);
+}
+
+export default function PosList() {
+  const [invoices, setInvoices] = useState<InvoiceSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    fetchJSON('/billing/invoices?status=PENDING,PARTIALLY_PAID')
+      .then((response) => {
+        if (!active) return;
+        setInvoices(response.data ?? []);
+      })
+      .catch((err) => {
+        console.error(err);
+        if (active) setError('Unable to load invoices.');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <DashboardLayout
+      title="Point of Sale"
+      subtitle="Collect payments for pending invoices"
+      activeItem="billing"
+    >
+      <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="border-b border-gray-200 px-4 py-3">
+          <h2 className="text-lg font-semibold text-gray-900">Outstanding invoices</h2>
+        </div>
+        {loading ? (
+          <div className="px-4 py-6 text-sm text-gray-500">Loading invoices...</div>
+        ) : error ? (
+          <div className="px-4 py-6 text-sm text-red-600">{error}</div>
+        ) : invoices.length === 0 ? (
+          <div className="px-4 py-6 text-sm text-gray-500">All caught up! No invoices awaiting payment.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-left font-medium text-gray-600">Invoice #</th>
+                  <th className="px-4 py-2 text-left font-medium text-gray-600">Patient</th>
+                  <th className="px-4 py-2 text-left font-medium text-gray-600">Status</th>
+                  <th className="px-4 py-2 text-right font-medium text-gray-600">Grand Total</th>
+                  <th className="px-4 py-2 text-right font-medium text-gray-600">Amount Due</th>
+                  <th className="px-4 py-2" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {invoices.map((invoice) => (
+                  <tr key={invoice.invoiceId}>
+                    <td className="px-4 py-2 font-medium text-gray-900">{invoice.invoiceNo}</td>
+                    <td className="px-4 py-2 text-gray-700">{invoice.Patient?.name ?? 'Unknown patient'}</td>
+                    <td className="px-4 py-2 text-gray-700">{invoice.status}</td>
+                    <td className="px-4 py-2 text-right text-gray-700">{formatMoney(invoice.grandTotal)}</td>
+                    <td className="px-4 py-2 text-right font-semibold text-gray-900">
+                      {formatMoney(invoice.amountDue)}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        type="button"
+                        onClick={() => navigate(`/billing/visit/${invoice.visitId}`)}
+                        className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+                      >
+                        Take Payment
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -24,6 +24,7 @@ type UserDraft = {
 const ROLE_LABELS: Record<Role, string> = {
   Doctor: 'Doctor',
   AdminAssistant: 'Administrative Assistant',
+  Cashier: 'Cashier',
   ITAdmin: 'IT Administrator',
   Pharmacist: 'Pharmacist',
   PharmacyTech: 'Pharmacy Technician',
@@ -33,6 +34,7 @@ const ROLE_LABELS: Record<Role, string> = {
 const ROLE_OPTIONS: Array<{ value: Role; label: string }> = [
   { value: 'Doctor', label: ROLE_LABELS.Doctor },
   { value: 'AdminAssistant', label: ROLE_LABELS.AdminAssistant },
+  { value: 'Cashier', label: ROLE_LABELS.Cashier },
   { value: 'ITAdmin', label: ROLE_LABELS.ITAdmin },
   { value: 'Pharmacist', label: ROLE_LABELS.Pharmacist },
   { value: 'PharmacyTech', label: ROLE_LABELS.PharmacyTech },

--- a/client/src/pages/SettingsServices.tsx
+++ b/client/src/pages/SettingsServices.tsx
@@ -1,0 +1,296 @@
+import { FormEvent, useEffect, useState } from 'react';
+import DashboardLayout from '../components/DashboardLayout';
+import { fetchJSON } from '../api/http';
+
+type Service = {
+  serviceId: string;
+  code: string;
+  name: string;
+  defaultPrice: string;
+  isActive: boolean;
+};
+
+type Draft = {
+  name: string;
+  defaultPrice: string;
+  isActive: boolean;
+};
+
+export default function SettingsServices() {
+  const [services, setServices] = useState<Service[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [createDraft, setCreateDraft] = useState({ code: '', name: '', defaultPrice: '' });
+  const [drafts, setDrafts] = useState<Record<string, Draft>>({});
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    fetchJSON('/billing/services')
+      .then((response) => {
+        if (!active) return;
+        const data = (response.data ?? []) as Service[];
+        setServices(data);
+        const nextDrafts: Record<string, Draft> = {};
+        data.forEach((service) => {
+          nextDrafts[service.serviceId] = {
+            name: service.name,
+            defaultPrice: service.defaultPrice,
+            isActive: service.isActive,
+          };
+        });
+        setDrafts(nextDrafts);
+      })
+      .catch((err) => {
+        console.error(err);
+        if (active) setError('Unable to load services.');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  async function refresh() {
+    const response = await fetchJSON('/billing/services');
+    const data = (response.data ?? []) as Service[];
+    setServices(data);
+    const nextDrafts: Record<string, Draft> = {};
+    data.forEach((service) => {
+      nextDrafts[service.serviceId] = {
+        name: service.name,
+        defaultPrice: service.defaultPrice,
+        isActive: service.isActive,
+      };
+    });
+    setDrafts(nextDrafts);
+  }
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setCreating(true);
+    setCreateError(null);
+    try {
+      await fetchJSON('/billing/services', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: createDraft.code,
+          name: createDraft.name,
+          defaultPrice: createDraft.defaultPrice,
+          isActive: true,
+        }),
+      });
+      setCreateDraft({ code: '', name: '', defaultPrice: '' });
+      await refresh();
+    } catch (err) {
+      console.error(err);
+      setCreateError('Unable to create service.');
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleSave(serviceId: string) {
+    const draft = drafts[serviceId];
+    if (!draft) return;
+    try {
+      await fetchJSON(`/billing/services/${serviceId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: draft.name,
+          defaultPrice: draft.defaultPrice,
+          isActive: draft.isActive,
+        }),
+      });
+      await refresh();
+    } catch (err) {
+      console.error(err);
+      window.alert('Unable to update service.');
+    }
+  }
+
+  async function handleDelete(serviceId: string) {
+    if (!window.confirm('Delete this service?')) return;
+    try {
+      await fetchJSON(`/billing/services/${serviceId}`, { method: 'DELETE' });
+      await refresh();
+    } catch (err) {
+      console.error(err);
+      window.alert('Unable to delete service.');
+    }
+  }
+
+  return (
+    <DashboardLayout title="Service Catalog" subtitle="Manage billable services" activeItem="settings">
+      <div className="grid gap-6 lg:grid-cols-3">
+        <section className="lg:col-span-2 rounded-lg border border-gray-200 bg-white shadow-sm">
+          <div className="border-b border-gray-200 px-4 py-3">
+            <h2 className="text-lg font-semibold text-gray-900">Available services</h2>
+          </div>
+          {loading ? (
+            <div className="px-4 py-6 text-sm text-gray-500">Loading catalog...</div>
+          ) : error ? (
+            <div className="px-4 py-6 text-sm text-red-600">{error}</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Code</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Name</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Default price</th>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Active</th>
+                    <th className="px-4 py-2 text-right" />
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {services.map((service) => {
+                    const draft = drafts[service.serviceId];
+                    return (
+                      <tr key={service.serviceId}>
+                        <td className="px-4 py-2 font-medium text-gray-900">{service.code}</td>
+                        <td className="px-4 py-2">
+                          <input
+                            type="text"
+                            value={draft?.name ?? service.name}
+                            onChange={(event) =>
+                              setDrafts((current) => ({
+                                ...current,
+                                [service.serviceId]: {
+                                  ...current[service.serviceId],
+                                  name: event.target.value,
+                                  defaultPrice:
+                                    current[service.serviceId]?.defaultPrice ?? service.defaultPrice,
+                                  isActive: current[service.serviceId]?.isActive ?? service.isActive,
+                                },
+                              }))
+                            }
+                            className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                          />
+                        </td>
+                        <td className="px-4 py-2">
+                          <input
+                            type="text"
+                            value={draft?.defaultPrice ?? service.defaultPrice}
+                            onChange={(event) =>
+                              setDrafts((current) => ({
+                                ...current,
+                                [service.serviceId]: {
+                                  ...current[service.serviceId],
+                                  name: current[service.serviceId]?.name ?? service.name,
+                                  defaultPrice: event.target.value,
+                                  isActive: current[service.serviceId]?.isActive ?? service.isActive,
+                                },
+                              }))
+                            }
+                            className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                          />
+                        </td>
+                        <td className="px-4 py-2">
+                          <label className="inline-flex items-center gap-2 text-sm text-gray-700">
+                            <input
+                              type="checkbox"
+                              checked={draft?.isActive ?? service.isActive}
+                              onChange={(event) =>
+                                setDrafts((current) => ({
+                                  ...current,
+                                  [service.serviceId]: {
+                                    ...current[service.serviceId],
+                                    name: current[service.serviceId]?.name ?? service.name,
+                                    defaultPrice:
+                                      current[service.serviceId]?.defaultPrice ?? service.defaultPrice,
+                                    isActive: event.target.checked,
+                                  },
+                                }))
+                              }
+                              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                            />
+                            Active
+                          </label>
+                        </td>
+                        <td className="px-4 py-2 text-right">
+                          <div className="flex justify-end gap-2">
+                            <button
+                              type="button"
+                              onClick={() => handleSave(service.serviceId)}
+                              className="rounded-full bg-blue-600 px-3 py-2 text-xs font-semibold text-white hover:bg-blue-700"
+                            >
+                              Save
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleDelete(service.serviceId)}
+                              className="rounded-full border border-red-200 px-3 py-2 text-xs font-semibold text-red-600 hover:bg-red-50"
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
+        <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+          <h2 className="text-lg font-semibold text-gray-900">Add service</h2>
+          <p className="mt-1 text-sm text-gray-500">Define new services for cashiering.</p>
+          <form className="mt-4 space-y-4" onSubmit={handleCreate}>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-medium text-gray-700">Code</span>
+              <input
+                type="text"
+                required
+                value={createDraft.code}
+                onChange={(event) => setCreateDraft((current) => ({ ...current, code: event.target.value }))}
+                className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-medium text-gray-700">Name</span>
+              <input
+                type="text"
+                required
+                value={createDraft.name}
+                onChange={(event) => setCreateDraft((current) => ({ ...current, name: event.target.value }))}
+                className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-medium text-gray-700">Default price</span>
+              <input
+                type="text"
+                required
+                value={createDraft.defaultPrice}
+                onChange={(event) =>
+                  setCreateDraft((current) => ({ ...current, defaultPrice: event.target.value }))
+                }
+                className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              />
+            </label>
+            {createError && <p className="text-sm text-red-600">{createError}</p>}
+            <button
+              type="submit"
+              disabled={creating}
+              className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {creating ? 'Saving…' : 'Add service'}
+            </button>
+          </form>
+        </section>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/src/pages/VisitBilling.tsx
+++ b/client/src/pages/VisitBilling.tsx
@@ -1,0 +1,456 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+import { fetchJSON } from '../api/http';
+import { getPatient, getVisit, type Patient, type VisitDetail as VisitDetailType } from '../api/client';
+
+type InvoiceItem = {
+  itemId: string;
+  description: string;
+  quantity: number;
+  unitPrice: string;
+  discountAmt: string;
+  taxAmt: string;
+  lineTotal: string;
+  sourceType: string;
+};
+
+type Invoice = {
+  invoiceId: string;
+  invoiceNo: string;
+  visitId: string;
+  patientId: string;
+  status: string;
+  currency: string;
+  note?: string | null;
+  subTotal: string;
+  discountAmt: string;
+  taxAmt: string;
+  grandTotal: string;
+  amountPaid: string;
+  amountDue: string;
+  items: InvoiceItem[];
+};
+
+type PaymentDraft = {
+  amount: string;
+  method: string;
+  referenceNo: string;
+  note: string;
+};
+
+const PAYMENT_METHODS = [
+  { value: 'CASH', label: 'Cash' },
+  { value: 'CARD', label: 'Card' },
+  { value: 'MOBILE_WALLET', label: 'Mobile Wallet' },
+  { value: 'BANK_TRANSFER', label: 'Bank Transfer' },
+  { value: 'OTHER', label: 'Other' },
+];
+
+function formatMoney(value: string) {
+  const numeric = Number.parseFloat(value);
+  if (Number.isNaN(numeric)) {
+    return value;
+  }
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'MMK' }).format(numeric);
+}
+
+export default function VisitBilling() {
+  const { visitId } = useParams<{ visitId: string }>();
+  const [visit, setVisit] = useState<VisitDetailType | null>(null);
+  const [patient, setPatient] = useState<Patient | null>(null);
+  const [invoice, setInvoice] = useState<Invoice | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [adjustmentDraft, setAdjustmentDraft] = useState({ discount: '', tax: '' });
+  const [isPaymentOpen, setPaymentOpen] = useState(false);
+  const [paymentDraft, setPaymentDraft] = useState<PaymentDraft>({
+    amount: '',
+    method: 'CASH',
+    referenceNo: '',
+    note: '',
+  });
+  const [paymentError, setPaymentError] = useState<string | null>(null);
+  const hasDue = useMemo(() => {
+    if (!invoice) return false;
+    const due = Number.parseFloat(invoice.amountDue);
+    return !Number.isNaN(due) && due > 0;
+  }, [invoice]);
+
+  useEffect(() => {
+    if (!visitId) {
+      setError('Visit identifier is missing.');
+      setLoading(false);
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    async function load(targetVisitId: string) {
+      try {
+        const visitDetails = await getVisit(targetVisitId);
+        if (!active) return;
+        setVisit(visitDetails);
+        const patientRecord = await getPatient(visitDetails.patientId);
+        if (!active) return;
+        setPatient(patientRecord as Patient);
+        let invoiceRecord: Invoice | null = null;
+        const existing = await fetchJSON(`/billing/invoices?visitId=${targetVisitId}`);
+        if (existing.data?.length) {
+          const detailed = await fetchJSON(`/billing/invoices/${existing.data[0].invoiceId}`);
+          invoiceRecord = detailed as Invoice;
+        } else {
+          const created = await fetchJSON('/billing/invoices', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ visitId: targetVisitId, patientId: visitDetails.patientId }),
+          });
+          const detailed = await fetchJSON(`/billing/invoices/${created.invoiceId}`);
+          invoiceRecord = detailed as Invoice;
+        }
+        if (!active) return;
+        setInvoice(invoiceRecord);
+        setAdjustmentDraft({
+          discount: invoiceRecord?.discountAmt ?? '0',
+          tax: invoiceRecord?.taxAmt ?? '0',
+        });
+      } catch (err) {
+        console.error(err);
+        if (active) {
+          setError('Unable to load invoice for this visit.');
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load(visitId);
+
+    return () => {
+      active = false;
+    };
+  }, [visitId]);
+
+  async function refreshInvoice() {
+    if (!invoice) return;
+    const detailed = await fetchJSON(`/billing/invoices/${invoice.invoiceId}`);
+    const refreshed = detailed as Invoice;
+    setInvoice(refreshed);
+    setAdjustmentDraft({ discount: refreshed.discountAmt ?? '0', tax: refreshed.taxAmt ?? '0' });
+  }
+
+  async function handleAdjustmentsSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!invoice) return;
+    try {
+      await fetchJSON(`/billing/invoices/${invoice.invoiceId}/items`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          invoiceDiscountAmt: adjustmentDraft.discount,
+          invoiceTaxAmt: adjustmentDraft.tax,
+        }),
+      });
+      await refreshInvoice();
+    } catch (err) {
+      console.error(err);
+      window.alert('Unable to update invoice totals.');
+    }
+  }
+
+  async function handlePostPayment(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!invoice) return;
+    setPaymentError(null);
+    try {
+      await fetchJSON(`/billing/invoices/${invoice.invoiceId}/payments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(paymentDraft),
+      });
+      setPaymentOpen(false);
+      setPaymentDraft({ amount: '', method: 'CASH', referenceNo: '', note: '' });
+      await refreshInvoice();
+    } catch (err) {
+      console.error(err);
+      setPaymentError('Unable to record payment right now.');
+    }
+  }
+
+  if (loading) {
+    return (
+      <DashboardLayout title="Visit Billing" subtitle="Preparing invoice..." activeItem="billing">
+        <div className="rounded-lg border border-dashed border-gray-300 p-8 text-center text-gray-500">
+          Loading invoice details...
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <DashboardLayout title="Visit Billing" subtitle="Invoice unavailable" activeItem="billing">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-red-700">{error}</div>
+      </DashboardLayout>
+    );
+  }
+
+  if (!invoice || !visit || !patient) {
+    return (
+      <DashboardLayout title="Visit Billing" subtitle="Invoice unavailable" activeItem="billing">
+        <div className="rounded-lg border border-gray-200 p-6 text-gray-600">Invoice data not found.</div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout
+      title={`Invoice ${invoice.invoiceNo}`}
+      subtitle={`Visit on ${new Date(visit.visitDate).toLocaleDateString('en-GB')}`}
+      activeItem="billing"
+      headerChildren={
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => window.open(`/api/billing/invoices/${invoice.invoiceId}/receipt`, '_blank')}
+            className="rounded-full border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+          >
+            Print Receipt
+          </button>
+          {hasDue && (
+            <button
+              type="button"
+              onClick={() => setPaymentOpen(true)}
+              className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+            >
+              Add Payment
+            </button>
+          )}
+        </div>
+      }
+    >
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-4">
+          <section className="rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div className="border-b border-gray-200 px-4 py-3">
+              <h2 className="text-lg font-semibold text-gray-900">Invoice Items</h2>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-medium text-gray-600">Description</th>
+                    <th className="px-4 py-2 text-right font-medium text-gray-600">Qty</th>
+                    <th className="px-4 py-2 text-right font-medium text-gray-600">Unit Price</th>
+                    <th className="px-4 py-2 text-right font-medium text-gray-600">Discount</th>
+                    <th className="px-4 py-2 text-right font-medium text-gray-600">Tax</th>
+                    <th className="px-4 py-2 text-right font-medium text-gray-600">Line Total</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {invoice.items.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} className="px-4 py-6 text-center text-gray-500">
+                        No items on this invoice yet.
+                      </td>
+                    </tr>
+                  ) : (
+                    invoice.items.map((item) => (
+                      <tr key={item.itemId}>
+                        <td className="px-4 py-2 text-gray-900">{item.description}</td>
+                        <td className="px-4 py-2 text-right text-gray-700">{item.quantity}</td>
+                        <td className="px-4 py-2 text-right text-gray-700">{formatMoney(item.unitPrice)}</td>
+                        <td className="px-4 py-2 text-right text-gray-700">{formatMoney(item.discountAmt)}</td>
+                        <td className="px-4 py-2 text-right text-gray-700">{formatMoney(item.taxAmt)}</td>
+                        <td className="px-4 py-2 text-right font-medium text-gray-900">{formatMoney(item.lineTotal)}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div className="border-b border-gray-200 px-4 py-3">
+              <h2 className="text-lg font-semibold text-gray-900">Invoice Adjustments</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                Apply invoice-level discount or tax. Amounts are absolute values in MMK.
+              </p>
+            </div>
+            <form className="grid gap-4 px-4 py-4 md:grid-cols-2" onSubmit={handleAdjustmentsSubmit}>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-gray-700">Invoice Discount</span>
+                <input
+                  type="text"
+                  value={adjustmentDraft.discount}
+                  onChange={(event) =>
+                    setAdjustmentDraft((state) => ({ ...state, discount: event.target.value }))
+                  }
+                  className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-gray-700">Invoice Tax</span>
+                <input
+                  type="text"
+                  value={adjustmentDraft.tax}
+                  onChange={(event) => setAdjustmentDraft((state) => ({ ...state, tax: event.target.value }))}
+                  className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                />
+              </label>
+              <div className="md:col-span-2 flex justify-end gap-3">
+                <button
+                  type="submit"
+                  className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+                >
+                  Save adjustments
+                </button>
+                <button
+                  type="button"
+                  className="rounded-full border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+                  onClick={() =>
+                    setAdjustmentDraft({ discount: invoice.discountAmt, tax: invoice.taxAmt })
+                  }
+                >
+                  Reset
+                </button>
+              </div>
+            </form>
+          </section>
+        </div>
+
+        <aside className="space-y-4">
+          <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <h3 className="text-base font-semibold text-gray-900">Patient</h3>
+            <dl className="mt-3 space-y-2 text-sm text-gray-700">
+              <div className="flex justify-between">
+                <dt className="text-gray-500">Name</dt>
+                <dd className="font-medium text-gray-900">{patient.name}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-gray-500">Visit Reason</dt>
+                <dd className="text-right text-gray-900">{visit.reason ?? '—'}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-gray-500">Status</dt>
+                <dd className="text-right font-medium text-gray-900">{invoice.status}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <h3 className="text-base font-semibold text-gray-900">Totals</h3>
+            <dl className="mt-3 space-y-2 text-sm text-gray-700">
+              <div className="flex justify-between">
+                <dt>Subtotal</dt>
+                <dd className="font-medium text-gray-900">{formatMoney(invoice.subTotal)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Discount</dt>
+                <dd>{formatMoney(invoice.discountAmt)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Tax</dt>
+                <dd>{formatMoney(invoice.taxAmt)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Grand Total</dt>
+                <dd className="font-semibold text-gray-900">{formatMoney(invoice.grandTotal)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Amount Paid</dt>
+                <dd>{formatMoney(invoice.amountPaid)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Amount Due</dt>
+                <dd className="font-semibold text-red-600">{formatMoney(invoice.amountDue)}</dd>
+              </div>
+            </dl>
+          </section>
+        </aside>
+      </div>
+
+      {isPaymentOpen && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-gray-900/40 px-4">
+          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+            <h3 className="text-lg font-semibold text-gray-900">Record Payment</h3>
+            <p className="mt-1 text-sm text-gray-500">Remaining due: {formatMoney(invoice.amountDue)}</p>
+            <form className="mt-4 space-y-4" onSubmit={handlePostPayment}>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-gray-700">Amount</span>
+                <input
+                  type="text"
+                  required
+                  value={paymentDraft.amount}
+                  onChange={(event) =>
+                    setPaymentDraft((state) => ({ ...state, amount: event.target.value }))
+                  }
+                  className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-gray-700">Method</span>
+                <select
+                  value={paymentDraft.method}
+                  onChange={(event) =>
+                    setPaymentDraft((state) => ({ ...state, method: event.target.value }))
+                  }
+                  className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                >
+                  {PAYMENT_METHODS.map((method) => (
+                    <option key={method.value} value={method.value}>
+                      {method.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-gray-700">Reference Number</span>
+                <input
+                  type="text"
+                  value={paymentDraft.referenceNo}
+                  onChange={(event) =>
+                    setPaymentDraft((state) => ({ ...state, referenceNo: event.target.value }))
+                  }
+                  className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-gray-700">Note</span>
+                <textarea
+                  value={paymentDraft.note}
+                  onChange={(event) =>
+                    setPaymentDraft((state) => ({ ...state, note: event.target.value }))
+                  }
+                  rows={3}
+                  className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                />
+              </label>
+              {paymentError && <p className="text-sm text-red-600">{paymentError}</p>}
+              <div className="flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={() => setPaymentOpen(false)}
+                  className="rounded-full border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+                >
+                  Save Payment
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from 'jest';
 const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/tests/**/*.test.ts']
+  testMatch: ['**/tests/**/*.test.ts', '**/tests/**/*.spec.ts']
 };
 
 export default config;

--- a/prisma/migrations/20250301000006_billing_mvp/migration.sql
+++ b/prisma/migrations/20250301000006_billing_mvp/migration.sql
@@ -1,0 +1,96 @@
+-- Billing & invoicing MVP
+ALTER TYPE "Role" ADD VALUE IF NOT EXISTS 'Cashier';
+
+CREATE TYPE "InvoiceStatus" AS ENUM ('DRAFT', 'PENDING', 'PARTIALLY_PAID', 'PAID', 'VOID', 'REFUNDED');
+CREATE TYPE "PaymentMethod" AS ENUM ('CASH', 'CARD', 'MOBILE_WALLET', 'BANK_TRANSFER', 'OTHER');
+CREATE TYPE "ItemSourceType" AS ENUM ('SERVICE', 'PHARMACY', 'LAB');
+
+CREATE TABLE "ServiceCatalog" (
+    "serviceId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "defaultPrice" DECIMAL(12, 2) NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT TRUE,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ServiceCatalog_pkey" PRIMARY KEY ("serviceId")
+);
+
+CREATE UNIQUE INDEX "ServiceCatalog_code_key" ON "ServiceCatalog"("code");
+
+CREATE TABLE "PriceList" (
+    "priceId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "serviceId" UUID NOT NULL,
+    "overridePrice" DECIMAL(12, 2),
+    "effectiveFrom" TIMESTAMPTZ(3),
+    CONSTRAINT "PriceList_pkey" PRIMARY KEY ("priceId"),
+    CONSTRAINT "PriceList_serviceId_fkey" FOREIGN KEY ("serviceId") REFERENCES "ServiceCatalog"("serviceId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "Invoice" (
+    "invoiceId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "invoiceNo" TEXT NOT NULL,
+    "visitId" UUID NOT NULL,
+    "patientId" UUID NOT NULL,
+    "status" "InvoiceStatus" NOT NULL DEFAULT 'DRAFT',
+    "currency" TEXT NOT NULL DEFAULT 'MMK',
+    "note" TEXT,
+    "subTotal" DECIMAL(12, 2) NOT NULL DEFAULT 0,
+    "discountAmt" DECIMAL(12, 2) NOT NULL DEFAULT 0,
+    "taxAmt" DECIMAL(12, 2) NOT NULL DEFAULT 0,
+    "grandTotal" DECIMAL(12, 2) NOT NULL DEFAULT 0,
+    "amountPaid" DECIMAL(12, 2) NOT NULL DEFAULT 0,
+    "amountDue" DECIMAL(12, 2) NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Invoice_pkey" PRIMARY KEY ("invoiceId"),
+    CONSTRAINT "Invoice_invoiceNo_key" UNIQUE ("invoiceNo"),
+    CONSTRAINT "Invoice_visitId_fkey" FOREIGN KEY ("visitId") REFERENCES "Visit"("visitId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Invoice_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient"("patientId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "Invoice_visitId_status_idx" ON "Invoice"("visitId", "status");
+
+CREATE TABLE "InvoiceItem" (
+    "itemId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "invoiceId" UUID NOT NULL,
+    "sourceType" "ItemSourceType" NOT NULL,
+    "sourceRefId" TEXT,
+    "serviceId" UUID,
+    "description" TEXT NOT NULL,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "unitPrice" DECIMAL(12, 2) NOT NULL,
+    "discountAmt" DECIMAL(12, 2) NOT NULL DEFAULT 0,
+    "taxAmt" DECIMAL(12, 2) NOT NULL DEFAULT 0,
+    "lineTotal" DECIMAL(12, 2) NOT NULL,
+    CONSTRAINT "InvoiceItem_pkey" PRIMARY KEY ("itemId"),
+    CONSTRAINT "InvoiceItem_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("invoiceId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "InvoiceItem_serviceId_fkey" FOREIGN KEY ("serviceId") REFERENCES "ServiceCatalog"("serviceId") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE INDEX "InvoiceItem_invoiceId_idx" ON "InvoiceItem"("invoiceId");
+CREATE INDEX "InvoiceItem_sourceType_sourceRefId_idx" ON "InvoiceItem"("sourceType", "sourceRefId");
+
+CREATE TABLE "Payment" (
+    "paymentId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "invoiceId" UUID NOT NULL,
+    "method" "PaymentMethod" NOT NULL,
+    "amount" DECIMAL(12, 2) NOT NULL,
+    "paidAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "referenceNo" TEXT,
+    "note" TEXT,
+    CONSTRAINT "Payment_pkey" PRIMARY KEY ("paymentId"),
+    CONSTRAINT "Payment_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("invoiceId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "Payment_invoiceId_idx" ON "Payment"("invoiceId");
+
+CREATE TABLE "PaymentAllocation" (
+    "allocationId" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "paymentId" UUID NOT NULL,
+    "invoiceId" UUID NOT NULL,
+    "amount" DECIMAL(12, 2) NOT NULL,
+    CONSTRAINT "PaymentAllocation_pkey" PRIMARY KEY ("allocationId"),
+    CONSTRAINT "PaymentAllocation_paymentId_fkey" FOREIGN KEY ("paymentId") REFERENCES "Payment"("paymentId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "PaymentAllocation_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("invoiceId") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ enum Gender {
 enum Role {
   Doctor
   AdminAssistant
+  Cashier
   ITAdmin
   Pharmacist
   PharmacyTech
@@ -48,6 +49,7 @@ model Patient {
   visits       Visit[]
   observations Observation[]
   prescriptions Prescription[]
+  invoices     Invoice[]
 }
 
 model Doctor {
@@ -127,6 +129,7 @@ model Visit {
   labResults   LabResult[]
   observations Observation[]
   prescriptions Prescription[]
+  invoices     Invoice[]
 
   @@index([patientId, visitDate(sort: Desc)])
   @@index([doctorId, visitDate(sort: Desc)])
@@ -361,4 +364,114 @@ enum DispenseStatus {
   PARTIAL
   COMPLETED
   CANCELLED
+}
+
+model ServiceCatalog {
+  serviceId    String      @id @default(uuid())
+  code         String      @unique
+  name         String
+  defaultPrice Decimal     @db.Decimal(12, 2)
+  isActive     Boolean     @default(true)
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
+  priceItems   PriceList[]
+  items        InvoiceItem[]
+}
+
+model PriceList {
+  priceId       String         @id @default(uuid())
+  serviceId     String
+  overridePrice Decimal?       @db.Decimal(12, 2)
+  effectiveFrom DateTime?
+  Service       ServiceCatalog @relation(fields: [serviceId], references: [serviceId], onDelete: Cascade)
+}
+
+model Invoice {
+  invoiceId   String        @id @default(uuid())
+  invoiceNo   String        @unique
+  visitId     String
+  patientId   String
+  status      InvoiceStatus @default(DRAFT)
+  currency    String        @default("MMK")
+  note        String?
+  subTotal    Decimal       @db.Decimal(12, 2) @default(0)
+  discountAmt Decimal       @db.Decimal(12, 2) @default(0)
+  taxAmt      Decimal       @db.Decimal(12, 2) @default(0)
+  grandTotal  Decimal       @db.Decimal(12, 2) @default(0)
+  amountPaid  Decimal       @db.Decimal(12, 2) @default(0)
+  amountDue   Decimal       @db.Decimal(12, 2) @default(0)
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  items       InvoiceItem[]
+  payments    Payment[]
+  Visit       Visit         @relation(fields: [visitId], references: [visitId], onDelete: Cascade)
+  Patient     Patient       @relation(fields: [patientId], references: [patientId], onDelete: Cascade)
+
+  @@index([visitId, status])
+}
+
+model InvoiceItem {
+  itemId      String         @id @default(uuid())
+  invoiceId   String
+  sourceType  ItemSourceType
+  sourceRefId String?
+  serviceId   String?
+  description String
+  quantity    Int            @default(1)
+  unitPrice   Decimal        @db.Decimal(12, 2)
+  discountAmt Decimal        @db.Decimal(12, 2) @default(0)
+  taxAmt      Decimal        @db.Decimal(12, 2) @default(0)
+  lineTotal   Decimal        @db.Decimal(12, 2)
+
+  Invoice Invoice @relation(fields: [invoiceId], references: [invoiceId], onDelete: Cascade)
+  Service ServiceCatalog? @relation(fields: [serviceId], references: [serviceId])
+
+  @@index([invoiceId])
+  @@index([sourceType, sourceRefId])
+}
+
+model Payment {
+  paymentId   String   @id @default(uuid())
+  invoiceId   String
+  method      PaymentMethod
+  amount      Decimal  @db.Decimal(12, 2)
+  paidAt      DateTime @default(now())
+  referenceNo String?
+  note        String?
+  allocations PaymentAllocation[]
+  Invoice     Invoice  @relation(fields: [invoiceId], references: [invoiceId], onDelete: Cascade)
+
+  @@index([invoiceId])
+}
+
+model PaymentAllocation {
+  allocationId String   @id @default(uuid())
+  paymentId    String
+  invoiceId    String
+  amount       Decimal  @db.Decimal(12, 2)
+
+  Payment Payment @relation(fields: [paymentId], references: [paymentId], onDelete: Cascade)
+}
+
+enum InvoiceStatus {
+  DRAFT
+  PENDING
+  PARTIALLY_PAID
+  PAID
+  VOID
+  REFUNDED
+}
+
+enum PaymentMethod {
+  CASH
+  CARD
+  MOBILE_WALLET
+  BANK_TRANSFER
+  OTHER
+}
+
+enum ItemSourceType {
+  SERVICE
+  PHARMACY
+  LAB
 }

--- a/prisma/seed.mts
+++ b/prisma/seed.mts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
@@ -61,6 +61,33 @@ async function seedPharmacyReference() {
 async function main() {
   // Run legacy seed first to ensure baseline data remains available.
   await import('./seed.mjs');
+  await prisma.serviceCatalog.upsert({
+    where: { code: 'CONSULT_OPD' },
+    update: { name: 'OPD Consultation', defaultPrice: new Prisma.Decimal(8000) },
+    create: {
+      code: 'CONSULT_OPD',
+      name: 'OPD Consultation',
+      defaultPrice: new Prisma.Decimal(8000),
+    },
+  });
+  await prisma.serviceCatalog.upsert({
+    where: { code: 'PROC_DRESSING' },
+    update: { name: 'Dressing', defaultPrice: new Prisma.Decimal(5000) },
+    create: {
+      code: 'PROC_DRESSING',
+      name: 'Dressing',
+      defaultPrice: new Prisma.Decimal(5000),
+    },
+  });
+  await prisma.serviceCatalog.upsert({
+    where: { code: 'PROC_INJ' },
+    update: { name: 'Injection', defaultPrice: new Prisma.Decimal(3000) },
+    create: {
+      code: 'PROC_INJ',
+      name: 'Injection',
+      defaultPrice: new Prisma.Decimal(3000),
+    },
+  });
   await seedPharmacyReference();
 }
 

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -7,6 +7,7 @@ import { PrismaClient } from '@prisma/client';
 type RoleName =
   | 'Doctor'
   | 'AdminAssistant'
+  | 'Cashier'
   | 'ITAdmin'
   | 'Pharmacist'
   | 'PharmacyTech'

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -1,0 +1,417 @@
+import { Router, type NextFunction, type Response } from 'express';
+import { InvoiceStatus, PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+
+import { requireAuth, requireRole, type AuthRequest } from '../modules/auth/index.js';
+import { validate } from '../middleware/validate.js';
+import {
+  AddInvoiceItemSchema,
+  CreateInvoiceSchema,
+  DecimalString,
+  PostPaymentSchema,
+  UpdateInvoiceItemSchema,
+  VoidInvoiceSchema,
+  type CreateInvoiceInput,
+  type InvoiceItemInput,
+} from '../validation/billing.js';
+import {
+  addInvoiceItem,
+  createInvoice,
+  postPayment,
+  removeInvoiceItem,
+  updateInvoiceAdjustments,
+  updateInvoiceItem,
+  voidInvoice,
+} from '../services/billingService.js';
+import { NotFoundError } from '../utils/httpErrors.js';
+import { postPharmacyCharges } from '../services/billingService.js';
+
+const prisma = new PrismaClient();
+const router = Router();
+
+const ModifyInvoiceItemsSchema = z
+  .object({
+    add: z.array(AddInvoiceItemSchema).optional(),
+    update: z
+      .array(
+        z.object({
+          itemId: z.string().uuid(),
+          patch: UpdateInvoiceItemSchema,
+        }),
+      )
+      .optional(),
+    invoiceDiscountAmt: DecimalString.optional(),
+    invoiceTaxAmt: DecimalString.optional(),
+  })
+  .refine(
+    (data) =>
+      Boolean(data.add?.length) ||
+      Boolean(data.update?.length) ||
+      typeof data.invoiceDiscountAmt !== 'undefined' ||
+      typeof data.invoiceTaxAmt !== 'undefined',
+    { message: 'No changes supplied' },
+  );
+
+const ListInvoicesQuerySchema = z.object({
+  visitId: z.string().uuid().optional(),
+  status: z
+    .string()
+    .optional()
+    .transform((value) =>
+      value
+        ?.split(',')
+        .map((entry) => entry.trim().toUpperCase())
+        .filter(Boolean) ?? [],
+    ),
+});
+
+router.use(requireAuth);
+
+router.post(
+  '/billing/invoices',
+  requireRole('Cashier', 'ITAdmin', 'Doctor', 'Pharmacist'),
+  validate({ body: CreateInvoiceSchema }),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const payload = req.body as CreateInvoiceInput;
+      const invoice = await createInvoice(payload);
+      res.status(201).json(invoice);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/billing/invoices',
+  requireRole('Cashier', 'ITAdmin', 'Doctor', 'Pharmacist'),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const parsed = ListInvoicesQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        return res.status(400).json({ error: parsed.error.flatten() });
+      }
+      const { visitId, status } = parsed.data;
+      const where: Parameters<typeof prisma.invoice.findMany>[0]['where'] = {};
+      if (visitId) {
+        where.visitId = visitId;
+      }
+      if (status && status.length) {
+        const allowed = status.filter((value): value is InvoiceStatus =>
+          (Object.values(InvoiceStatus) as string[]).includes(value),
+        );
+        if (allowed.length) {
+          where.status = { in: allowed };
+        }
+      }
+      const invoices = await prisma.invoice.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          Patient: true,
+        },
+      });
+      res.json({ data: invoices });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/billing/invoices/:invoiceId',
+  requireRole('Cashier', 'ITAdmin', 'Doctor', 'Pharmacist'),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const invoice = await prisma.invoice.findUnique({
+        where: { invoiceId: req.params.invoiceId },
+        include: {
+          items: true,
+          payments: { include: { allocations: true } },
+          Patient: true,
+          Visit: true,
+        },
+      });
+      if (!invoice) {
+        throw new NotFoundError('Invoice not found');
+      }
+      res.json(invoice);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.patch(
+  '/billing/invoices/:invoiceId/items',
+  requireRole('Cashier', 'ITAdmin'),
+  validate({ body: ModifyInvoiceItemsSchema }),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const invoiceId = req.params.invoiceId;
+      const body = req.body as z.infer<typeof ModifyInvoiceItemsSchema>;
+      const results: unknown[] = [];
+      if (body.add) {
+        for (const item of body.add as InvoiceItemInput[]) {
+          results.push(await addInvoiceItem(invoiceId, item));
+        }
+      }
+      if (body.update) {
+        for (const entry of body.update) {
+          results.push(await updateInvoiceItem(entry.itemId, entry.patch));
+        }
+      }
+      if (typeof body.invoiceDiscountAmt !== 'undefined' || typeof body.invoiceTaxAmt !== 'undefined') {
+        const invoice = await updateInvoiceAdjustments(
+          invoiceId,
+          body.invoiceDiscountAmt,
+          body.invoiceTaxAmt,
+        );
+        results.push(invoice);
+      }
+      res.json({ updated: results.length ? results : null });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.delete(
+  '/billing/items/:itemId',
+  requireRole('Cashier', 'ITAdmin'),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      await removeInvoiceItem(req.params.itemId);
+      res.status(204).end();
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/billing/invoices/:invoiceId/payments',
+  requireRole('Cashier', 'ITAdmin'),
+  validate({ body: PostPaymentSchema }),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { amount, method, referenceNo, note } = req.body as z.infer<typeof PostPaymentSchema>;
+      const payment = await postPayment(req.params.invoiceId, amount, method, referenceNo, note);
+      res.status(201).json(payment);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/billing/invoices/:invoiceId/void',
+  requireRole('Cashier', 'ITAdmin'),
+  validate({ body: VoidInvoiceSchema }),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const body = req.body as z.infer<typeof VoidInvoiceSchema>;
+      const invoice = await voidInvoice(req.params.invoiceId, body.reason);
+      res.json(invoice);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/billing/services',
+  requireRole('ITAdmin', 'Cashier', 'Doctor', 'Pharmacist'),
+  async (_req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const services = await prisma.serviceCatalog.findMany({
+        orderBy: { name: 'asc' },
+      });
+      res.json({ data: services });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/billing/services',
+  requireRole('ITAdmin'),
+  validate({
+    body: z.object({
+      code: z.string().trim().min(1),
+      name: z.string().trim().min(1),
+      defaultPrice: DecimalString,
+      isActive: z.boolean().optional(),
+    }),
+  }),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { code, name, defaultPrice, isActive = true } = req.body as {
+        code: string;
+        name: string;
+        defaultPrice: string;
+        isActive?: boolean;
+      };
+      const service = await prisma.serviceCatalog.create({
+        data: {
+          code,
+          name,
+          defaultPrice,
+          isActive,
+        },
+      });
+      res.status(201).json(service);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.put(
+  '/billing/services/:serviceId',
+  requireRole('ITAdmin'),
+  validate({
+    body: z.object({
+      name: z.string().trim().min(1),
+      defaultPrice: DecimalString,
+      isActive: z.boolean().optional(),
+    }),
+  }),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const body = req.body as { name: string; defaultPrice: string; isActive?: boolean };
+      const updated = await prisma.serviceCatalog.update({
+        where: { serviceId: req.params.serviceId },
+        data: {
+          name: body.name,
+          defaultPrice: body.defaultPrice,
+          isActive: typeof body.isActive === 'boolean' ? body.isActive : undefined,
+        },
+      });
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.delete(
+  '/billing/services/:serviceId',
+  requireRole('ITAdmin'),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      await prisma.serviceCatalog.delete({ where: { serviceId: req.params.serviceId } });
+      res.status(204).end();
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/billing/post-pharmacy/:prescriptionId',
+  requireRole('Pharmacist', 'PharmacyTech', 'ITAdmin'),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const invoice = await postPharmacyCharges(req.params.prescriptionId);
+      res.json({ invoiceId: invoice?.invoiceId ?? null });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/billing/invoices/:invoiceId/receipt',
+  requireRole('Cashier', 'ITAdmin', 'Doctor', 'Pharmacist'),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const invoice = await prisma.invoice.findUnique({
+        where: { invoiceId: req.params.invoiceId },
+        include: {
+          items: true,
+          Patient: true,
+          Visit: true,
+        },
+      });
+      if (!invoice) {
+        throw new NotFoundError('Invoice not found');
+      }
+      const createdAt = new Date(invoice.createdAt);
+      const receiptHtml = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Invoice ${invoice.invoiceNo}</title>
+    <style>
+      body { font-family: Arial, sans-serif; padding: 24px; }
+      h1 { font-size: 20px; margin-bottom: 8px; }
+      table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+      th, td { border: 1px solid #ddd; padding: 8px; font-size: 13px; }
+      th { background: #f4f4f5; text-align: left; }
+      tfoot td { font-weight: bold; }
+    </style>
+  </head>
+  <body>
+    <h1>Invoice ${invoice.invoiceNo}</h1>
+    <p><strong>Patient:</strong> ${invoice.Patient?.name ?? 'Unknown'}</p>
+    <p><strong>Visit Date:</strong> ${createdAt.toLocaleString('en-GB', {
+        timeZone: 'Asia/Yangon',
+      })}</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Description</th>
+          <th>Qty</th>
+          <th>Unit Price</th>
+          <th>Line Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${invoice.items
+          .map(
+            (item) => `
+            <tr>
+              <td>${item.description}</td>
+              <td>${item.quantity}</td>
+              <td>${item.unitPrice.toString()}</td>
+              <td>${item.lineTotal.toString()}</td>
+            </tr>`,
+          )
+          .join('')}
+      </tbody>
+      <tfoot>
+        <tr>
+          <td colspan="3">Subtotal</td>
+          <td>${invoice.subTotal.toString()}</td>
+        </tr>
+        <tr>
+          <td colspan="3">Discount</td>
+          <td>${invoice.discountAmt.toString()}</td>
+        </tr>
+        <tr>
+          <td colspan="3">Tax</td>
+          <td>${invoice.taxAmt.toString()}</td>
+        </tr>
+        <tr>
+          <td colspan="3">Grand Total</td>
+          <td>${invoice.grandTotal.toString()}</td>
+        </tr>
+        <tr>
+          <td colspan="3">Amount Due</td>
+          <td>${invoice.amountDue.toString()}</td>
+        </tr>
+      </tfoot>
+    </table>
+  </body>
+</html>`;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.send(receiptHtml);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import appointmentsRouter from './routes/appointments.js';
 import usersRouter from './modules/users/index.js';
 import reportsRouter from './modules/reports/index.js';
 import pharmacyRouter from './routes/pharmacy.js';
+import billingRouter from './routes/billing.js';
 
 export const apiRouter = Router();
 
@@ -35,6 +36,7 @@ apiRouter.use('/appointments', appointmentsRouter);
 apiRouter.use('/users', usersRouter);
 apiRouter.use('/reports', reportsRouter);
 apiRouter.use('/pharmacy', pharmacyRouter);
+apiRouter.use(billingRouter);
 apiRouter.use(docsRouter);
 
 export default apiRouter;

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -1,0 +1,491 @@
+import {
+  InvoiceStatus,
+  ItemSourceType,
+  PaymentMethod,
+  Prisma,
+  PrismaClient,
+} from '@prisma/client';
+import { BadRequestError, NotFoundError } from '../utils/httpErrors.js';
+import type {
+  CreateInvoiceInput,
+  InvoiceItemInput,
+  UpdateInvoiceItemInput,
+} from '../validation/billing.js';
+
+const prisma = new PrismaClient();
+const { Decimal } = Prisma;
+
+type TransactionClient = Prisma.TransactionClient | PrismaClient;
+
+function toDecimal(value: string | undefined): Prisma.Decimal {
+  if (typeof value === 'undefined') {
+    return new Decimal(0);
+  }
+  return new Decimal(value);
+}
+
+function normalizeMoney(value: Prisma.Decimal): Prisma.Decimal {
+  return value.toDecimalPlaces(2, Prisma.Decimal.ROUND_HALF_UP);
+}
+
+function ensureNonNegative(value: Prisma.Decimal, message: string) {
+  if (value.lessThan(0)) {
+    throw new BadRequestError(message);
+  }
+}
+
+function formatYangonDate(date: Date): string {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Yangon',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = formatter.format(date).split('-');
+  return parts.join('');
+}
+
+async function buildInvoiceItemData(
+  tx: TransactionClient,
+  invoiceId: string,
+  payload: InvoiceItemInput,
+) {
+  let description = payload.description?.trim();
+  if (!description && payload.sourceType === ItemSourceType.SERVICE && payload.serviceId) {
+    const service = await tx.serviceCatalog.findUnique({
+      where: { serviceId: payload.serviceId },
+    });
+    if (!service) {
+      throw new NotFoundError('Service not found');
+    }
+    description = service.name;
+  }
+
+  if (!description) {
+    throw new BadRequestError('Description is required');
+  }
+
+  const quantity = payload.quantity;
+  const unitPrice = normalizeMoney(toDecimal(payload.unitPrice));
+  const discountAmt = normalizeMoney(toDecimal(payload.discountAmt));
+  const taxAmt = normalizeMoney(toDecimal(payload.taxAmt));
+
+  ensureNonNegative(discountAmt, 'Discount cannot be negative');
+  ensureNonNegative(taxAmt, 'Tax cannot be negative');
+
+  const base = normalizeMoney(unitPrice.mul(quantity));
+  ensureNonNegative(base, 'Base amount cannot be negative');
+
+  if (discountAmt.greaterThan(base)) {
+    throw new BadRequestError('Discount cannot exceed line base amount');
+  }
+
+  const lineTotal = normalizeMoney(base.minus(discountAmt).plus(taxAmt));
+  ensureNonNegative(lineTotal, 'Line total cannot be negative');
+
+  return {
+    invoiceId,
+    sourceType: payload.sourceType,
+    sourceRefId: payload.sourceRefId ?? null,
+    serviceId: payload.serviceId ?? null,
+    description,
+    quantity,
+    unitPrice,
+    discountAmt,
+    taxAmt,
+    lineTotal,
+  } satisfies Prisma.InvoiceItemUncheckedCreateInput;
+}
+
+async function assertInvoiceEditable(invoice: { status: InvoiceStatus }) {
+  if (invoice.status === InvoiceStatus.VOID || invoice.status === InvoiceStatus.REFUNDED) {
+    throw new BadRequestError('Invoice is void and cannot be modified');
+  }
+}
+
+export async function generateInvoiceNo(tx: TransactionClient = prisma) {
+  const dateCode = formatYangonDate(new Date());
+  const prefix = `INV-${dateCode}-`;
+  const count = await tx.invoice.count({
+    where: { invoiceNo: { startsWith: prefix } },
+  });
+  const sequence = (count + 1).toString().padStart(4, '0');
+  return `${prefix}${sequence}`;
+}
+
+export async function computeTotals(invoiceId: string, tx: TransactionClient = prisma) {
+  const invoice = await tx.invoice.findUnique({
+    where: { invoiceId },
+    include: {
+      items: true,
+      payments: { include: { allocations: true } },
+    },
+  });
+
+  if (!invoice) {
+    throw new NotFoundError('Invoice not found');
+  }
+
+  const zero = new Decimal(0);
+  const subTotal = invoice.items.reduce((sum, item) => sum.plus(item.lineTotal), zero);
+  const normalizedSubTotal = normalizeMoney(subTotal);
+
+  const invoiceDiscount = normalizeMoney(invoice.discountAmt ?? zero);
+  const invoiceTax = normalizeMoney(invoice.taxAmt ?? zero);
+
+  let grandTotal = normalizeMoney(normalizedSubTotal.minus(invoiceDiscount).plus(invoiceTax));
+  if (grandTotal.lessThan(0)) {
+    grandTotal = zero;
+  }
+
+  const amountPaid = invoice.payments.reduce((acc, payment) => {
+    const allocated = payment.allocations.reduce(
+      (sum, allocation) => sum.plus(allocation.amount),
+      zero,
+    );
+    return acc.plus(allocated);
+  }, zero);
+  const normalizedPaid = normalizeMoney(amountPaid);
+
+  let amountDue = normalizeMoney(grandTotal.minus(normalizedPaid));
+  if (amountDue.lessThan(0)) {
+    amountDue = zero;
+  }
+
+  let status = invoice.status;
+  if (status === InvoiceStatus.VOID || status === InvoiceStatus.REFUNDED) {
+    amountDue = zero;
+  } else if (invoice.items.length === 0 && normalizedPaid.equals(zero)) {
+    status = InvoiceStatus.DRAFT;
+  } else if (amountDue.equals(grandTotal)) {
+    status = InvoiceStatus.PENDING;
+  } else if (amountDue.greaterThan(zero)) {
+    status = InvoiceStatus.PARTIALLY_PAID;
+  } else {
+    status = InvoiceStatus.PAID;
+  }
+
+  return tx.invoice.update({
+    where: { invoiceId },
+    data: {
+      subTotal: normalizedSubTotal,
+      discountAmt: invoiceDiscount,
+      taxAmt: invoiceTax,
+      grandTotal,
+      amountPaid: normalizedPaid,
+      amountDue,
+      status,
+    },
+  });
+}
+
+export async function createInvoice(payload: CreateInvoiceInput) {
+  return prisma.$transaction(async (tx) => {
+    const invoiceNo = await generateInvoiceNo(tx);
+    const discountAmt = normalizeMoney(toDecimal(payload.invoiceDiscountAmt));
+    const taxAmt = normalizeMoney(toDecimal(payload.invoiceTaxAmt));
+    ensureNonNegative(discountAmt, 'Invoice discount cannot be negative');
+    ensureNonNegative(taxAmt, 'Invoice tax cannot be negative');
+    const invoice = await tx.invoice.create({
+      data: {
+        invoiceNo,
+        visitId: payload.visitId,
+        patientId: payload.patientId,
+        note: payload.note ?? null,
+        discountAmt,
+        taxAmt,
+      },
+    });
+
+    if (payload.items?.length) {
+      for (const item of payload.items) {
+        const data = await buildInvoiceItemData(tx, invoice.invoiceId, item);
+        await tx.invoiceItem.create({ data });
+      }
+    }
+
+    return computeTotals(invoice.invoiceId, tx);
+  });
+}
+
+export async function addInvoiceItem(invoiceId: string, item: InvoiceItemInput) {
+  return prisma.$transaction(async (tx) => {
+    const invoice = await tx.invoice.findUnique({ where: { invoiceId } });
+    if (!invoice) {
+      throw new NotFoundError('Invoice not found');
+    }
+    await assertInvoiceEditable(invoice);
+    const data = await buildInvoiceItemData(tx, invoiceId, item);
+    const created = await tx.invoiceItem.create({ data });
+    await computeTotals(invoiceId, tx);
+    return created;
+  });
+}
+
+export async function updateInvoiceItem(itemId: string, patch: UpdateInvoiceItemInput) {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.invoiceItem.findUnique({
+      where: { itemId },
+      include: { Invoice: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundError('Invoice item not found');
+    }
+
+    await assertInvoiceEditable(existing.Invoice);
+
+    const quantity = patch.quantity ?? existing.quantity;
+    const unitPrice = patch.unitPrice ? normalizeMoney(toDecimal(patch.unitPrice)) : existing.unitPrice;
+    const discountAmt = patch.discountAmt
+      ? normalizeMoney(toDecimal(patch.discountAmt))
+      : existing.discountAmt;
+    const taxAmt = patch.taxAmt ? normalizeMoney(toDecimal(patch.taxAmt)) : existing.taxAmt;
+
+    ensureNonNegative(discountAmt, 'Discount cannot be negative');
+    ensureNonNegative(taxAmt, 'Tax cannot be negative');
+
+    const base = normalizeMoney(unitPrice.mul(quantity));
+    ensureNonNegative(base, 'Base amount cannot be negative');
+
+    if (discountAmt.greaterThan(base)) {
+      throw new BadRequestError('Discount cannot exceed line base amount');
+    }
+
+    const lineTotal = normalizeMoney(base.minus(discountAmt).plus(taxAmt));
+    ensureNonNegative(lineTotal, 'Line total cannot be negative');
+
+    const updated = await tx.invoiceItem.update({
+      where: { itemId },
+      data: {
+        description: patch.description?.trim() ?? existing.description,
+        quantity,
+        unitPrice,
+        discountAmt,
+        taxAmt,
+        lineTotal,
+      },
+    });
+
+    await computeTotals(existing.invoiceId, tx);
+    return updated;
+  });
+}
+
+export async function removeInvoiceItem(itemId: string) {
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.invoiceItem.findUnique({
+      where: { itemId },
+      include: { Invoice: true },
+    });
+    if (!existing) {
+      throw new NotFoundError('Invoice item not found');
+    }
+    await assertInvoiceEditable(existing.Invoice);
+    await tx.invoiceItem.delete({ where: { itemId } });
+    await computeTotals(existing.invoiceId, tx);
+  });
+}
+
+export async function updateInvoiceAdjustments(
+  invoiceId: string,
+  invoiceDiscountAmt?: string,
+  invoiceTaxAmt?: string,
+) {
+  return prisma.$transaction(async (tx) => {
+    const invoice = await tx.invoice.findUnique({ where: { invoiceId } });
+    if (!invoice) {
+      throw new NotFoundError('Invoice not found');
+    }
+    await assertInvoiceEditable(invoice);
+    const discountAmt =
+      typeof invoiceDiscountAmt !== 'undefined'
+        ? normalizeMoney(toDecimal(invoiceDiscountAmt))
+        : invoice.discountAmt;
+    const taxAmt =
+      typeof invoiceTaxAmt !== 'undefined' ? normalizeMoney(toDecimal(invoiceTaxAmt)) : invoice.taxAmt;
+
+    if (discountAmt.lessThan(0) || taxAmt.lessThan(0)) {
+      throw new BadRequestError('Discount and tax must be non-negative');
+    }
+
+    await tx.invoice.update({
+      where: { invoiceId },
+      data: {
+        discountAmt,
+        taxAmt,
+      },
+    });
+    return computeTotals(invoiceId, tx);
+  });
+}
+
+export async function postPayment(
+  invoiceId: string,
+  amount: string,
+  method: PaymentMethod,
+  referenceNo?: string,
+  note?: string,
+) {
+  return prisma.$transaction(async (tx) => {
+    const invoice = await tx.invoice.findUnique({ where: { invoiceId } });
+    if (!invoice) {
+      throw new NotFoundError('Invoice not found');
+    }
+    await assertInvoiceEditable(invoice);
+
+    const paymentAmount = normalizeMoney(toDecimal(amount));
+    if (paymentAmount.lessThanOrEqualTo(0)) {
+      throw new BadRequestError('Payment amount must be greater than zero');
+    }
+
+    const payment = await tx.payment.create({
+      data: {
+        invoiceId,
+        method,
+        amount: paymentAmount,
+        referenceNo: referenceNo ?? null,
+        note: note ?? null,
+      },
+    });
+
+    await tx.paymentAllocation.create({
+      data: {
+        paymentId: payment.paymentId,
+        invoiceId,
+        amount: paymentAmount,
+      },
+    });
+
+    await computeTotals(invoiceId, tx);
+    return payment;
+  });
+}
+
+export async function voidInvoice(invoiceId: string, reason: string) {
+  return prisma.$transaction(async (tx) => {
+    const invoice = await tx.invoice.findUnique({ where: { invoiceId } });
+    if (!invoice) {
+      throw new NotFoundError('Invoice not found');
+    }
+    if (invoice.status === InvoiceStatus.VOID) {
+      return invoice;
+    }
+
+    await tx.invoice.update({
+      where: { invoiceId },
+      data: {
+        status: InvoiceStatus.VOID,
+        amountDue: new Decimal(0),
+        note: reason ? `${invoice.note ? `${invoice.note}\n` : ''}Voided: ${reason}` : invoice.note,
+      },
+    });
+
+    return computeTotals(invoiceId, tx);
+  });
+}
+
+export async function ensurePharmacyChargeForDispenseItem(dispenseItemId: string) {
+  return prisma.$transaction(async (tx) => {
+    const item = await tx.dispenseItem.findUnique({
+      where: { dispenseItemId: dispenseItemId },
+      include: {
+        drug: true,
+        dispense: {
+          include: {
+            prescription: true,
+          },
+        },
+      },
+    });
+
+    if (!item || !item.dispense.prescription) {
+      throw new NotFoundError('Dispense item not found');
+    }
+
+    const prescription = item.dispense.prescription;
+    let invoice = await tx.invoice.findFirst({
+      where: {
+        visitId: prescription.visitId,
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    if (!invoice) {
+      invoice = await tx.invoice.create({
+        data: {
+          invoiceNo: await generateInvoiceNo(tx),
+          visitId: prescription.visitId,
+          patientId: prescription.patientId,
+          status: InvoiceStatus.DRAFT,
+        },
+      });
+    }
+
+    if (invoice.status === InvoiceStatus.VOID || invoice.status === InvoiceStatus.PAID) {
+      return invoice;
+    }
+
+    const existingCharge = await tx.invoiceItem.findFirst({
+      where: {
+        invoiceId: invoice.invoiceId,
+        sourceType: ItemSourceType.PHARMACY,
+        sourceRefId: dispenseItemId,
+      },
+    });
+
+    if (existingCharge) {
+      return invoice;
+    }
+
+    const description = `${item.drug.name} x ${item.quantity}`;
+    const unitPrice = normalizeMoney(item.unitPrice ?? new Decimal(0));
+    ensureNonNegative(unitPrice, 'Unit price cannot be negative');
+    const lineTotal = normalizeMoney(unitPrice);
+
+    await tx.invoiceItem.create({
+      data: {
+        invoiceId: invoice.invoiceId,
+        sourceType: ItemSourceType.PHARMACY,
+        sourceRefId: dispenseItemId,
+        serviceId: null,
+        description,
+        quantity: 1,
+        unitPrice,
+        discountAmt: new Decimal(0),
+        taxAmt: new Decimal(0),
+        lineTotal,
+      },
+    });
+
+    await computeTotals(invoice.invoiceId, tx);
+    return tx.invoice.findUnique({ where: { invoiceId: invoice.invoiceId } });
+  });
+}
+
+export async function postPharmacyCharges(prescriptionId: string) {
+  const dispenses = await prisma.dispense.findMany({
+    where: { prescriptionId, status: 'COMPLETED' },
+    include: { items: true },
+  });
+
+  let invoiceId: string | null = null;
+  for (const dispense of dispenses) {
+    for (const item of dispense.items) {
+      const invoice = await ensurePharmacyChargeForDispenseItem(item.dispenseItemId);
+      invoiceId = invoice?.invoiceId ?? invoiceId;
+    }
+  }
+
+  if (!invoiceId) {
+    return null;
+  }
+
+  return prisma.invoice.findUnique({
+    where: { invoiceId },
+    include: {
+      items: true,
+      payments: true,
+    },
+  });
+}

--- a/src/services/pharmacyService.ts
+++ b/src/services/pharmacyService.ts
@@ -261,6 +261,6 @@ export async function completeDispense(
       data: { status: finalStatus },
     });
 
-    return { ok: true, prescriptionStatus: finalStatus };
+    return { ok: true, prescriptionStatus: finalStatus, prescriptionId: dispense.prescriptionId };
   });
 }

--- a/src/validation/billing.ts
+++ b/src/validation/billing.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+export const DecimalString = z
+  .union([z.string(), z.number()])
+  .transform((value) => {
+    if (typeof value === 'number') {
+      return value.toString();
+    }
+    return value.trim();
+  })
+  .refine((value) => /^-?\d+(\.\d{1,})?$/.test(value), {
+    message: 'Invalid monetary amount',
+  });
+
+const ItemSourceTypeEnum = z.enum(['SERVICE', 'PHARMACY', 'LAB']);
+const PaymentMethodEnum = z.enum(['CASH', 'CARD', 'MOBILE_WALLET', 'BANK_TRANSFER', 'OTHER']);
+
+export const InvoiceItemInputSchema = z.object({
+  sourceType: ItemSourceTypeEnum,
+  sourceRefId: z.string().uuid().optional(),
+  serviceId: z.string().uuid().optional(),
+  description: z.string().trim().min(1).optional(),
+  quantity: z.coerce.number().int().positive(),
+  unitPrice: DecimalString,
+  discountAmt: DecimalString.optional(),
+  taxAmt: DecimalString.optional(),
+});
+
+export const CreateInvoiceSchema = z.object({
+  visitId: z.string().uuid(),
+  patientId: z.string().uuid(),
+  note: z.string().max(500).optional(),
+  items: z.array(InvoiceItemInputSchema).optional(),
+  invoiceDiscountAmt: DecimalString.optional(),
+  invoiceTaxAmt: DecimalString.optional(),
+});
+
+export const AddInvoiceItemSchema = InvoiceItemInputSchema;
+
+export const UpdateInvoiceItemSchema = z
+  .object({
+    description: z.string().trim().min(1).optional(),
+    quantity: z.coerce.number().int().positive().optional(),
+    unitPrice: DecimalString.optional(),
+    discountAmt: DecimalString.optional(),
+    taxAmt: DecimalString.optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+export const PostPaymentSchema = z.object({
+  amount: DecimalString,
+  method: PaymentMethodEnum,
+  referenceNo: z.string().max(100).optional(),
+  note: z.string().max(500).optional(),
+});
+
+export const VoidInvoiceSchema = z.object({
+  reason: z.string().trim().min(1),
+});
+
+export type CreateInvoiceInput = z.infer<typeof CreateInvoiceSchema>;
+export type InvoiceItemInput = z.infer<typeof InvoiceItemInputSchema>;
+export type UpdateInvoiceItemInput = z.infer<typeof UpdateInvoiceItemSchema>;
+export type PostPaymentInput = z.infer<typeof PostPaymentSchema>;
+export type VoidInvoiceInput = z.infer<typeof VoidInvoiceSchema>;

--- a/tests/billing.spec.ts
+++ b/tests/billing.spec.ts
@@ -1,0 +1,314 @@
+import request from 'supertest';
+import { PrismaClient } from '@prisma/client';
+import { app } from '../src/index';
+
+const prisma = new PrismaClient();
+
+function makeAuthHeader(userId: string, role: string, email: string) {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ sub: userId, role, email })).toString('base64url');
+  return `Bearer ${header}.${payload}.`;
+}
+
+let doctorId: string;
+let patientId: string;
+let visitId: string;
+let cashierUserId: string;
+let pharmacistUserId: string;
+let serviceId: string;
+let invoiceId: string;
+let pharmacyDrugId: string;
+let prescriptionId: string;
+let dispenseId: string;
+
+beforeAll(async () => {
+  const doctor = await prisma.doctor.create({ data: { name: 'Dr Billing', department: 'General' } });
+  doctorId = doctor.doctorId;
+  const patient = await prisma.patient.create({
+    data: {
+      name: 'Billing Patient',
+      dob: new Date('1990-01-01'),
+      gender: 'M',
+    },
+  });
+  patientId = patient.patientId;
+  const visit = await prisma.visit.create({
+    data: {
+      patientId,
+      doctorId,
+      visitDate: new Date('2024-01-01'),
+      department: 'General',
+      reason: 'Routine check',
+    },
+  });
+  visitId = visit.visitId;
+
+  const cashier = await prisma.user.create({
+    data: {
+      email: 'cashier@example.com',
+      passwordHash: 'x',
+      role: 'Cashier',
+    },
+  });
+  cashierUserId = cashier.userId;
+
+  const pharmacist = await prisma.user.create({
+    data: {
+      email: 'pharma-cashier@example.com',
+      passwordHash: 'x',
+      role: 'Pharmacist',
+    },
+  });
+  pharmacistUserId = pharmacist.userId;
+
+  const service = await prisma.serviceCatalog.create({
+    data: {
+      code: 'CONSULT_TEST',
+      name: 'Test Consultation',
+      defaultPrice: '8000.00',
+    },
+  });
+  serviceId = service.serviceId;
+});
+
+afterAll(async () => {
+  await prisma.paymentAllocation.deleteMany({});
+  await prisma.payment.deleteMany({});
+  await prisma.invoiceItem.deleteMany({});
+  await prisma.invoice.deleteMany({});
+  await prisma.serviceCatalog.deleteMany({ where: { serviceId } });
+  if (dispenseId) {
+    await prisma.dispenseItem.deleteMany({ where: { dispenseId } });
+    await prisma.dispense.deleteMany({ where: { dispenseId } });
+  }
+  if (prescriptionId) {
+    await prisma.prescriptionItem.deleteMany({ where: { prescriptionId } });
+    await prisma.prescription.deleteMany({ where: { prescriptionId } });
+  }
+  if (pharmacyDrugId) {
+    await prisma.drug.deleteMany({ where: { drugId: pharmacyDrugId } });
+  }
+  await prisma.visit.deleteMany({ where: { visitId } });
+  await prisma.patient.deleteMany({ where: { patientId } });
+  await prisma.doctor.deleteMany({ where: { doctorId } });
+  await prisma.user.deleteMany({ where: { userId: { in: [cashierUserId, pharmacistUserId] } } });
+  await prisma.$disconnect();
+});
+
+describe('Billing & invoicing', () => {
+  it('creates invoice with items and computes totals', async () => {
+    const cashierAuth = makeAuthHeader(cashierUserId, 'Cashier', 'cashier@example.com');
+
+    const createRes = await request(app)
+      .post('/api/billing/invoices')
+      .set('Authorization', cashierAuth)
+      .send({
+        visitId,
+        patientId,
+        items: [
+          {
+            sourceType: 'SERVICE',
+            serviceId,
+            description: 'Consultation',
+            quantity: 1,
+            unitPrice: '8000.00',
+          },
+        ],
+      });
+
+    expect(createRes.status).toBe(201);
+    invoiceId = createRes.body.invoiceId as string;
+    expect(createRes.body.status).toBe('PENDING');
+    expect(createRes.body.subTotal).toBe('8000.00');
+    expect(createRes.body.grandTotal).toBe('8000.00');
+
+    const detailRes = await request(app)
+      .get(`/api/billing/invoices/${invoiceId}`)
+      .set('Authorization', cashierAuth);
+
+    expect(detailRes.status).toBe(200);
+    expect(detailRes.body.items).toHaveLength(1);
+    expect(detailRes.body.amountDue).toBe('8000.00');
+  });
+
+  it('records partial payment and updates status', async () => {
+    const cashierAuth = makeAuthHeader(cashierUserId, 'Cashier', 'cashier@example.com');
+
+    const paymentRes = await request(app)
+      .post(`/api/billing/invoices/${invoiceId}/payments`)
+      .set('Authorization', cashierAuth)
+      .send({ amount: '3000.00', method: 'CASH' });
+
+    expect(paymentRes.status).toBe(201);
+
+    const detailRes = await request(app)
+      .get(`/api/billing/invoices/${invoiceId}`)
+      .set('Authorization', cashierAuth);
+
+    expect(detailRes.body.amountPaid).toBe('3000.00');
+    expect(detailRes.body.amountDue).toBe('5000.00');
+    expect(detailRes.body.status).toBe('PARTIALLY_PAID');
+  });
+
+  it('records full payment and closes invoice', async () => {
+    const cashierAuth = makeAuthHeader(cashierUserId, 'Cashier', 'cashier@example.com');
+
+    const paymentRes = await request(app)
+      .post(`/api/billing/invoices/${invoiceId}/payments`)
+      .set('Authorization', cashierAuth)
+      .send({ amount: '5000.00', method: 'CARD' });
+
+    expect(paymentRes.status).toBe(201);
+
+    const detailRes = await request(app)
+      .get(`/api/billing/invoices/${invoiceId}`)
+      .set('Authorization', cashierAuth);
+
+    expect(detailRes.body.amountPaid).toBe('8000.00');
+    expect(detailRes.body.amountDue).toBe('0.00');
+    expect(detailRes.body.status).toBe('PAID');
+  });
+
+  it('void invoice prevents further mutations', async () => {
+    const cashierAuth = makeAuthHeader(cashierUserId, 'Cashier', 'cashier@example.com');
+
+    const createRes = await request(app)
+      .post('/api/billing/invoices')
+      .set('Authorization', cashierAuth)
+      .send({ visitId, patientId });
+
+    expect(createRes.status).toBe(201);
+    const voidInvoiceId = createRes.body.invoiceId as string;
+
+    const voidRes = await request(app)
+      .post(`/api/billing/invoices/${voidInvoiceId}/void`)
+      .set('Authorization', cashierAuth)
+      .send({ reason: 'Test void' });
+
+    expect(voidRes.status).toBe(200);
+    expect(voidRes.body.status).toBe('VOID');
+
+    const addItemRes = await request(app)
+      .patch(`/api/billing/invoices/${voidInvoiceId}/items`)
+      .set('Authorization', cashierAuth)
+      .send({
+        add: [
+          {
+            sourceType: 'SERVICE',
+            serviceId,
+            description: 'Follow up',
+            quantity: 1,
+            unitPrice: '1000.00',
+          },
+        ],
+      });
+
+    expect(addItemRes.status).toBe(400);
+
+    const paymentRes = await request(app)
+      .post(`/api/billing/invoices/${voidInvoiceId}/payments`)
+      .set('Authorization', cashierAuth)
+      .send({ amount: '1000.00', method: 'CASH' });
+
+    expect(paymentRes.status).toBe(400);
+  });
+
+  it('posts pharmacy charges once for completed dispense', async () => {
+    const pharmacistAuth = makeAuthHeader(
+      pharmacistUserId,
+      'Pharmacist',
+      'pharma-cashier@example.com',
+    );
+    const cashierAuth = makeAuthHeader(cashierUserId, 'Cashier', 'cashier@example.com');
+
+    const drug = await prisma.drug.create({
+      data: {
+        name: 'Dispense Drug',
+        genericName: 'dispense',
+        form: 'tab',
+        strength: '10 mg',
+      },
+    });
+    pharmacyDrugId = drug.drugId;
+
+    const prescription = await prisma.prescription.create({
+      data: {
+        visitId,
+        doctorId,
+        patientId,
+        items: {
+          create: [
+            {
+              drugId: drug.drugId,
+              dose: '10 mg',
+              route: 'PO',
+              frequency: 'BID',
+              durationDays: 5,
+              quantityPrescribed: 10,
+            },
+          ],
+        },
+      },
+      include: { items: true },
+    });
+    prescriptionId = prescription.prescriptionId;
+
+    const dispense = await prisma.dispense.create({
+      data: {
+        prescriptionId: prescription.prescriptionId,
+        pharmacistId: pharmacistUserId,
+        status: 'READY',
+        items: {
+          create: [
+            {
+              prescriptionItemId: prescription.items[0].itemId,
+              drugId: drug.drugId,
+              quantity: 5,
+              unitPrice: '0.00',
+            },
+          ],
+        },
+      },
+      include: { items: true },
+    });
+    dispenseId = dispense.dispenseId;
+
+    const completeRes = await request(app)
+      .patch(`/api/dispenses/${dispenseId}/complete`)
+      .set('Authorization', pharmacistAuth)
+      .send({ status: 'COMPLETED' });
+
+    expect(completeRes.status).toBe(200);
+    expect(completeRes.body.invoiceId).toBeTruthy();
+    const pharmacyInvoiceId = completeRes.body.invoiceId as string;
+
+    const listRes = await request(app)
+      .get(`/api/billing/invoices?visitId=${visitId}`)
+      .set('Authorization', cashierAuth);
+
+    expect(listRes.status).toBe(200);
+    const matching = listRes.body.data.find(
+      (entry: { invoiceId: string }) => entry.invoiceId === pharmacyInvoiceId,
+    );
+    expect(matching).toBeDefined();
+
+    const detailRes = await request(app)
+      .get(`/api/billing/invoices/${pharmacyInvoiceId}`)
+      .set('Authorization', cashierAuth);
+
+    expect(detailRes.body.items).toHaveLength(1);
+
+    const repostRes = await request(app)
+      .post(`/api/billing/post-pharmacy/${prescriptionId}`)
+      .set('Authorization', pharmacistAuth);
+
+    expect(repostRes.status).toBe(200);
+    expect(repostRes.body.invoiceId).toBe(pharmacyInvoiceId);
+
+    const detailAgain = await request(app)
+      .get(`/api/billing/invoices/${pharmacyInvoiceId}`)
+      .set('Authorization', cashierAuth);
+
+    expect(detailAgain.body.items).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Prisma billing models, enums, and seed data for service catalog basics【F:prisma/schema.prisma†L369-L477】【F:prisma/seed.mts†L1-L100】
- implement billing services for invoice lifecycle, payment posting, and pharmacy charge synchronization【F:src/services/billingService.ts†L1-L490】
- expose billing API routes with RBAC, receipt rendering, and integrate completion workflow from pharmacy【F:src/routes/billing.ts†L1-L400】【F:src/routes/pharmacy.ts†L302-L337】【F:src/server.ts†L15-L36】
- extend auth and navigation with the Cashier role plus new billing and service settings pages on the client【F:src/modules/auth/index.ts†L7-L18】【F:client/src/components/DashboardLayout.tsx†L20-L140】【F:client/src/App.tsx†L1-L180】
- deliver visit billing, POS queue, and service catalog management UIs with supporting validation and tests【F:client/src/pages/VisitBilling.tsx†L1-L220】【F:client/src/pages/PosList.tsx†L1-L112】【F:client/src/pages/SettingsServices.tsx†L1-L200】【F:src/validation/billing.ts†L1-L67】【F:tests/billing.spec.ts†L1-L200】

## Testing
- `npm test` *(fails: Jest cannot load ESM entrypoint `src/index.ts` under current runner configuration)*【794a48†L1-L63】

------
https://chatgpt.com/codex/tasks/task_e_68d809a040c8832ea9e1c38d1275c502