### PR TITLE
Fix TypeScript issues in billing and invoice scanning

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -337,6 +337,7 @@ function ITAdminDashboard() {
 
 const ACCOUNT_ROLE_LABELS: Record<UserAccount['role'], string> = {
   Doctor: 'Doctor',
+  Cashier: 'Cashier',
   AdminAssistant: 'Administrative Assistant',
   ITAdmin: 'IT Administrator',
   Pharmacist: 'Pharmacist',

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -1,5 +1,5 @@
 import { Router, type NextFunction, type Response } from 'express';
-import { InvoiceStatus, PrismaClient } from '@prisma/client';
+import { InvoiceStatus, PrismaClient, type Prisma } from '@prisma/client';
 import { z } from 'zod';
 
 import { requireAuth, requireRole, type AuthRequest } from '../modules/auth/index.js';
@@ -92,7 +92,7 @@ router.get(
         return res.status(400).json({ error: parsed.error.flatten() });
       }
       const { visitId, status } = parsed.data;
-      const where: Parameters<typeof prisma.invoice.findMany>[0]['where'] = {};
+      const where: Prisma.InvoiceWhereInput = {};
       if (visitId) {
         where.visitId = visitId;
       }

--- a/src/services/invoiceScanner.ts
+++ b/src/services/invoiceScanner.ts
@@ -218,7 +218,9 @@ export async function scanInvoice(buffer: Buffer, mimeType?: string | null): Pro
             },
             {
               type: 'image_url',
-              image_url: imageUrl,
+              image_url: {
+                url: imageUrl,
+              },
             },
           ],
         },


### PR DESCRIPTION
## Summary
- type the billing invoice filter with Prisma's InvoiceWhereInput to allow property assignment
- send the OpenAI image payload using the expected object structure in the invoice scanner
- add the missing Cashier role label so the client TypeScript build succeeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d893da75c0832ea192bb55c081ce3f