### PR TITLE
Allow cashier role for user management

### DIFF
--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -11,6 +11,7 @@ const router = Router();
 const roleSchema = z.enum([
   'Doctor',
   'AdminAssistant',
+  'Cashier',
   'ITAdmin',
   'Pharmacist',
   'PharmacyTech',


### PR DESCRIPTION
## Summary
- allow the Cashier role to be selected when creating or updating users by extending the server-side role validation

## Testing
- npm test -- --runTestsByPath tests/auth.test.ts *(fails: Must use import to load ES Module: /workspace/EMR/src/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d897d8bc34832e9a4e2170ef7fc64f