### PR TITLE
Handle pharmacy invoice PDF uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "morgan": "^1",
         "multer": "^2.0.0",
         "openai": "^4.77.3",
+        "pdf-parse": "^1.1.1",
         "prisma": "^6.15.0",
         "zod": "^3"
       },
@@ -27,6 +28,7 @@
         "@types/morgan": "^1",
         "@types/multer": "^1.4.12",
         "@types/node": "^20.19.13",
+        "@types/pdf-parse": "^1.1.5",
         "@types/supertest": "^2",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
@@ -2171,6 +2173,16 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -6432,6 +6444,12 @@
         "node": ">=10.5.0"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -6808,6 +6826,28 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,13 @@
     "seed": "tsx prisma/seed.mts"
   },
   "devDependencies": {
+    "@types/cors": "^2",
+    "@types/express": "^4",
     "@types/jest": "^29",
+    "@types/morgan": "^1",
     "@types/multer": "^1.4.12",
     "@types/node": "^20.19.13",
+    "@types/pdf-parse": "^1.1.5",
     "@types/supertest": "^2",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
@@ -39,9 +43,6 @@
     "dotenv": "^17.2.2",
     "eslint": "^9.35.0",
     "jest": "^29",
-    "@types/express": "^4",
-    "@types/cors": "^2",
-    "@types/morgan": "^1",
     "supertest": "^6",
     "ts-jest": "^29",
     "ts-node": "^10.9.2",
@@ -58,8 +59,9 @@
     "express-rate-limit": "^7",
     "helmet": "^7",
     "morgan": "^1",
-    "openai": "^4.77.3",
     "multer": "^2.0.0",
+    "openai": "^4.77.3",
+    "pdf-parse": "^1.1.1",
     "prisma": "^6.15.0",
     "zod": "^3"
   }


### PR DESCRIPTION
## Summary
- add a pdf-parse based fallback so invoice scanning can process PDF uploads
- send sanitized PDF text to OpenAI when vision parsing is not available
- include pdf-parse runtime dependency and its type definitions

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d900325c9c832e89ccd5f51b8dce25