### PR TITLE
Add clinical vitals, problems, and lab workflow support

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,9 @@ import VisitBilling from './pages/VisitBilling';
 import PosList from './pages/PosList';
 import BillingWorkspace from './pages/BillingWorkspace';
 import SettingsServices from './pages/SettingsServices';
+import ProblemList from './pages/ProblemList';
+import LabOrdersPage from './pages/LabOrders';
+import LabOrderDetailPage from './pages/LabOrderDetail';
 import './styles/App.css';
 
 function App() {
@@ -40,6 +43,14 @@ function App() {
         element={
           <RouteGuard>
             <PatientDetail />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/patients/:patientId/problems"
+        element={
+          <RouteGuard allowedRoles={['Doctor', 'Nurse', 'ITAdmin']}>
+            <ProblemList />
           </RouteGuard>
         }
       />
@@ -112,6 +123,22 @@ function App() {
         element={
           <RouteGuard>
             <Reports />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/lab-orders"
+        element={
+          <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin']}>
+            <LabOrdersPage />
+          </RouteGuard>
+        }
+      />
+      <Route
+        path="/lab-orders/:labOrderId"
+        element={
+          <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin']}>
+            <LabOrderDetailPage />
           </RouteGuard>
         }
       />

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -7,7 +7,9 @@ export type Role =
   | 'ITAdmin'
   | 'Pharmacist'
   | 'PharmacyTech'
-  | 'InventoryManager';
+  | 'InventoryManager'
+  | 'Nurse'
+  | 'LabTech';
 
 export interface Patient {
   patientId: string;
@@ -136,7 +138,7 @@ export interface InvoiceScanResult {
   rawText?: string | null;
 }
 
-export interface LabResult {
+export interface VisitLabResult {
   testName: string;
   resultValue: number | null;
   unit: string | null;
@@ -171,7 +173,7 @@ export interface VisitSummary {
   doctor: Doctor;
   diagnoses: Diagnosis[];
   medications: Medication[];
-  labResults: LabResult[];
+  labResults: VisitLabResult[];
   observations: Observation[];
 }
 
@@ -182,7 +184,7 @@ export interface PatientSummary extends Patient {
 export interface VisitDetail extends Visit {
   diagnoses: Diagnosis[];
   medications: Medication[];
-  labResults: LabResult[];
+  labResults: VisitLabResult[];
   observations: Observation[];
 }
 
@@ -420,7 +422,7 @@ export interface AddLabResultPayload {
 export async function addLabResult(
   visitId: string,
   payload: AddLabResultPayload,
-): Promise<LabResult> {
+): Promise<VisitLabResult> {
   return fetchJSON(`/visits/${visitId}/labs`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/client/src/api/clinical.ts
+++ b/client/src/api/clinical.ts
@@ -1,0 +1,209 @@
+import { fetchJSON } from './http';
+
+export interface VitalsEntry {
+  vitalsId: string;
+  visitId: string;
+  patientId: string;
+  recordedBy: string;
+  recordedAt: string;
+  systolic: number | null;
+  diastolic: number | null;
+  heartRate: number | null;
+  temperature: number | null;
+  spo2: number | null;
+  heightCm: number | null;
+  weightKg: number | null;
+  bmi: number | null;
+  notes: string | null;
+}
+
+export interface CreateVitalsPayload {
+  visitId: string;
+  patientId: string;
+  systolic?: number | null;
+  diastolic?: number | null;
+  heartRate?: number | null;
+  temperature?: number | null;
+  spo2?: number | null;
+  heightCm?: number | null;
+  weightKg?: number | null;
+  notes?: string;
+}
+
+export async function createVitals(payload: CreateVitalsPayload): Promise<VitalsEntry> {
+  return fetchJSON('/vitals', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function listVitals(
+  patientId: string,
+  limit = 25,
+): Promise<VitalsEntry[]> {
+  const query = new URLSearchParams({ limit: String(limit) });
+  const response = await fetchJSON(`/patients/${patientId}/vitals?${query.toString()}`);
+  return response.data as VitalsEntry[];
+}
+
+export type ProblemStatus = 'ACTIVE' | 'RESOLVED';
+
+export interface ProblemEntry {
+  problemId: string;
+  patientId: string;
+  codeSystem: string | null;
+  code: string | null;
+  display: string;
+  onsetDate: string | null;
+  status: ProblemStatus;
+  resolvedDate: string | null;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateProblemPayload {
+  patientId: string;
+  codeSystem?: string;
+  code?: string;
+  display: string;
+  onsetDate?: string;
+  status?: ProblemStatus;
+  resolvedDate?: string;
+}
+
+export async function createProblem(payload: CreateProblemPayload): Promise<ProblemEntry> {
+  return fetchJSON('/problems', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function listProblems(
+  patientId: string,
+  status?: ProblemStatus | 'ALL',
+): Promise<ProblemEntry[]> {
+  const params = new URLSearchParams();
+  if (status && status !== 'ALL') {
+    params.set('status', status);
+  }
+  const query = params.toString();
+  const response = await fetchJSON(`/patients/${patientId}/problems${query ? `?${query}` : ''}`);
+  return response.data as ProblemEntry[];
+}
+
+export async function updateProblemStatus(
+  problemId: string,
+  status: ProblemStatus,
+  resolvedDate?: string,
+): Promise<ProblemEntry> {
+  return fetchJSON(`/problems/${problemId}/status`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status, resolvedDate }),
+  });
+}
+
+export type LabOrderStatus = 'ORDERED' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+export type LabItemStatus = 'ORDERED' | 'RESULTED' | 'CANCELLED';
+
+export interface LabOrderItemEntry {
+  labOrderItemId: string;
+  labOrderId: string;
+  testCode: string;
+  testName: string;
+  status: LabItemStatus;
+  specimen: string | null;
+  notes: string | null;
+  results?: LabResultEntry[];
+}
+
+export interface LabOrderEntry {
+  labOrderId: string;
+  visitId: string;
+  patientId: string;
+  doctorId: string;
+  status: LabOrderStatus;
+  priority: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+  items: LabOrderItemEntry[];
+  results: LabResultEntry[];
+}
+
+export interface LabResultEntry {
+  labResultId: string;
+  labOrderId: string;
+  labOrderItemId: string;
+  patientId: string;
+  resultValue: string | null;
+  resultValueNum: number | null;
+  unit: string | null;
+  referenceLow: number | null;
+  referenceHigh: number | null;
+  abnormalFlag: string | null;
+  resultedBy: string;
+  resultedAt: string;
+  notes: string | null;
+}
+
+export interface CreateLabOrderPayload {
+  visitId: string;
+  patientId: string;
+  priority?: string;
+  notes?: string;
+  items: Array<{
+    testCode: string;
+    testName: string;
+    specimen?: string;
+    notes?: string;
+  }>;
+}
+
+export async function createLabOrder(payload: CreateLabOrderPayload): Promise<LabOrderEntry> {
+  return fetchJSON('/lab-orders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function listLabOrders(params: {
+  patientId?: string;
+  visitId?: string;
+  status?: LabOrderStatus | '';
+}): Promise<LabOrderEntry[]> {
+  const search = new URLSearchParams();
+  if (params.patientId) search.set('patientId', params.patientId);
+  if (params.visitId) search.set('visitId', params.visitId);
+  if (params.status) search.set('status', params.status);
+  const query = search.toString();
+  const response = await fetchJSON(`/lab-orders${query ? `?${query}` : ''}`);
+  return response.data as LabOrderEntry[];
+}
+
+export async function getLabOrderDetail(labOrderId: string): Promise<LabOrderEntry | null> {
+  return fetchJSON(`/lab-orders/${labOrderId}`);
+}
+
+export interface EnterLabResultPayload {
+  labOrderItemId: string;
+  patientId?: string;
+  resultValue?: string;
+  resultValueNum?: number;
+  unit?: string;
+  referenceLow?: number;
+  referenceHigh?: number;
+  notes?: string;
+}
+
+export async function enterLabResult(payload: EnterLabResultPayload): Promise<LabResultEntry> {
+  return fetchJSON('/lab-results', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -23,6 +23,7 @@ type NavigationKey =
   | 'appointments'
   | 'billing'
   | 'pharmacy'
+  | 'lab'
   | 'reports'
   | 'settings';
 
@@ -39,6 +40,7 @@ const navigation: NavigationItem[] = [
   { key: 'appointments', name: 'Appointments', icon: CalendarIcon, to: '/appointments' },
   { key: 'billing', name: 'Billing', icon: ReportsIcon, to: '/billing/workspace' },
   { key: 'pharmacy', name: 'Pharmacy', icon: PharmacyIcon, to: '/pharmacy/queue' },
+  { key: 'lab', name: 'Lab Orders', icon: ReportsIcon, to: '/lab-orders' },
   { key: 'reports', name: 'Reports', icon: ReportsIcon, to: '/reports' },
   { key: 'settings', name: 'Settings', icon: SettingsIcon, to: '/settings' },
 ];
@@ -87,6 +89,9 @@ export default function DashboardLayout({
       return (
         user && ['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin'].includes(user.role)
       );
+    }
+    if (item.key === 'lab') {
+      return user && ['Doctor', 'LabTech', 'ITAdmin'].includes(user.role);
     }
     return true;
   });
@@ -271,4 +276,6 @@ const ROLE_LABELS: Record<string, string> = {
   Pharmacist: 'Pharmacist',
   PharmacyTech: 'Pharmacy Technician',
   InventoryManager: 'Inventory Manager',
+  Nurse: 'Nurse',
+  LabTech: 'Laboratory Technician',
 };

--- a/client/src/components/VitalsCard.tsx
+++ b/client/src/components/VitalsCard.tsx
@@ -1,0 +1,301 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useAuth } from '../context/AuthProvider';
+import {
+  createVitals,
+  listVitals,
+  type CreateVitalsPayload,
+  type VitalsEntry,
+} from '../api/clinical';
+import { useTranslation } from '../hooks/useTranslation';
+
+interface VitalsCardProps {
+  patientId: string;
+  defaultVisitId?: string;
+  limit?: number;
+}
+
+type VitalsFormState = {
+  visitId: string;
+  systolic: string;
+  diastolic: string;
+  heartRate: string;
+  temperature: string;
+  spo2: string;
+  heightCm: string;
+  weightKg: string;
+  notes: string;
+};
+
+export default function VitalsCard({ patientId, defaultVisitId = '', limit = 10 }: VitalsCardProps) {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const canRecord = useMemo(
+    () => user && ['Nurse', 'Doctor', 'ITAdmin'].includes(user.role),
+    [user],
+  );
+  const [vitalsList, setVitalsList] = useState<VitalsEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState<VitalsFormState>({
+    visitId: defaultVisitId,
+    systolic: '',
+    diastolic: '',
+    heartRate: '',
+    temperature: '',
+    spo2: '',
+    heightCm: '',
+    weightKg: '',
+    notes: '',
+  });
+
+  useEffect(() => {
+    setForm((prev) => ({ ...prev, visitId: defaultVisitId }));
+  }, [defaultVisitId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await listVitals(patientId, limit);
+        if (!cancelled) {
+          setVitalsList(data);
+        }
+      } catch (err) {
+        console.error(err);
+        if (!cancelled) {
+          setError(t('Failed to load vitals.'));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [patientId, limit, t]);
+
+  function parseNumber(value: string): number | null {
+    if (!value) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canRecord) return;
+    if (!form.visitId) {
+      setError(t('Visit ID is required to record vitals.'));
+      return;
+    }
+
+    const payload: CreateVitalsPayload = {
+      visitId: form.visitId,
+      patientId,
+      systolic: parseNumber(form.systolic) ?? undefined,
+      diastolic: parseNumber(form.diastolic) ?? undefined,
+      heartRate: parseNumber(form.heartRate) ?? undefined,
+      temperature: parseNumber(form.temperature) ?? undefined,
+      spo2: parseNumber(form.spo2) ?? undefined,
+      heightCm: parseNumber(form.heightCm) ?? undefined,
+      weightKg: parseNumber(form.weightKg) ?? undefined,
+      notes: form.notes ? form.notes.trim() : undefined,
+    };
+
+    setSaving(true);
+    setError(null);
+    try {
+      const created = await createVitals(payload);
+      setVitalsList((prev) => [created, ...prev].slice(0, limit));
+      setForm({
+        visitId: form.visitId,
+        systolic: '',
+        diastolic: '',
+        heartRate: '',
+        temperature: '',
+        spo2: '',
+        heightCm: '',
+        weightKg: '',
+        notes: '',
+      });
+    } catch (err) {
+      console.error(err);
+      setError(t('Unable to save vitals entry.'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl bg-white p-6 shadow-sm">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">{t('Vitals')}</h2>
+        {loading && <span className="text-sm text-gray-500">{t('Loading...')}</span>}
+      </div>
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+      {canRecord && (
+        <form onSubmit={handleSubmit} className="mb-6 space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <label className="flex flex-col text-sm font-medium text-gray-700">
+              {t('Visit ID')}
+              <input
+                type="text"
+                value={form.visitId}
+                onChange={(event) => setForm((prev) => ({ ...prev, visitId: event.target.value }))}
+                className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                placeholder={t('Enter visit ID')}
+                required
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-gray-700">
+              {t('Systolic (mmHg)')}
+              <input
+                type="number"
+                value={form.systolic}
+                onChange={(event) => setForm((prev) => ({ ...prev, systolic: event.target.value }))}
+                className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-gray-700">
+              {t('Diastolic (mmHg)')}
+              <input
+                type="number"
+                value={form.diastolic}
+                onChange={(event) => setForm((prev) => ({ ...prev, diastolic: event.target.value }))}
+                className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-gray-700">
+              {t('Heart Rate (bpm)')}
+              <input
+                type="number"
+                value={form.heartRate}
+                onChange={(event) => setForm((prev) => ({ ...prev, heartRate: event.target.value }))}
+                className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-gray-700">
+              {t('Temperature (°C)')}
+              <input
+                type="number"
+                step="0.1"
+                value={form.temperature}
+                onChange={(event) => setForm((prev) => ({ ...prev, temperature: event.target.value }))}
+                className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-gray-700">
+              {t('SpO₂ (%)')}
+              <input
+                type="number"
+                value={form.spo2}
+                onChange={(event) => setForm((prev) => ({ ...prev, spo2: event.target.value }))}
+                className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-gray-700">
+              {t('Height (cm)')}
+              <input
+                type="number"
+                step="0.1"
+                value={form.heightCm}
+                onChange={(event) => setForm((prev) => ({ ...prev, heightCm: event.target.value }))}
+                className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-gray-700">
+              {t('Weight (kg)')}
+              <input
+                type="number"
+                step="0.1"
+                value={form.weightKg}
+                onChange={(event) => setForm((prev) => ({ ...prev, weightKg: event.target.value }))}
+                className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-gray-700 sm:col-span-2 lg:col-span-3">
+              {t('Notes')}
+              <textarea
+                value={form.notes}
+                onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+                className="mt-1 h-20 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                maxLength={500}
+              />
+            </label>
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={saving}
+              className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-400"
+            >
+              {saving ? t('Saving...') : t('Record vitals')}
+            </button>
+          </div>
+        </form>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-gray-500">
+              <th className="px-3 py-2">{t('Recorded At')}</th>
+              <th className="px-3 py-2">{t('BP')}</th>
+              <th className="px-3 py-2">{t('Heart Rate')}</th>
+              <th className="px-3 py-2">{t('Temperature')}</th>
+              <th className="px-3 py-2">{t('SpO₂')}</th>
+              <th className="px-3 py-2">{t('BMI')}</th>
+              <th className="px-3 py-2">{t('Notes')}</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {vitalsList.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-3 py-4 text-center text-sm text-gray-500">
+                  {t('No vitals captured yet.')}
+                </td>
+              </tr>
+            ) : (
+              vitalsList.map((entry) => (
+                <tr key={entry.vitalsId}>
+                  <td className="px-3 py-2 text-gray-700">
+                    {new Date(entry.recordedAt).toLocaleString()}
+                  </td>
+                  <td className="px-3 py-2 text-gray-700">
+                    {entry.systolic && entry.diastolic
+                      ? `${entry.systolic}/${entry.diastolic} mmHg`
+                      : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-gray-700">
+                    {entry.heartRate != null ? `${entry.heartRate} bpm` : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-gray-700">
+                    {entry.temperature != null ? `${entry.temperature.toFixed(1)} °C` : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-gray-700">
+                    {entry.spo2 != null ? `${entry.spo2}%` : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-gray-700">
+                    {entry.bmi != null ? entry.bmi.toFixed(2) : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-gray-600">
+                    {entry.notes ?? '—'}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -343,6 +343,8 @@ const ACCOUNT_ROLE_LABELS: Record<UserAccount['role'], string> = {
   Pharmacist: 'Pharmacist',
   PharmacyTech: 'Pharmacy Technician',
   InventoryManager: 'Inventory Manager',
+  Nurse: 'Nurse',
+  LabTech: 'Laboratory Technician',
 };
 
 const STATUS_LABELS: Record<UserAccount['status'], 'Active' | 'Inactive'> = {

--- a/client/src/pages/LabOrderDetail.tsx
+++ b/client/src/pages/LabOrderDetail.tsx
@@ -1,0 +1,344 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+import { useTranslation } from '../hooks/useTranslation';
+import { useAuth } from '../context/AuthProvider';
+import {
+  enterLabResult,
+  getLabOrderDetail,
+  type EnterLabResultPayload,
+  type LabOrderEntry,
+  type LabOrderItemEntry,
+  type LabResultEntry,
+} from '../api/clinical';
+
+interface Params {
+  labOrderId: string;
+}
+
+type ResultFormState = {
+  resultValue: string;
+  resultValueNum: string;
+  unit: string;
+  referenceLow: string;
+  referenceHigh: string;
+  notes: string;
+};
+
+type ResultForms = Record<string, ResultFormState>;
+
+export default function LabOrderDetailPage() {
+  const { t } = useTranslation();
+  const { labOrderId } = useParams<Params>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const canEnterResults = useMemo(() => user && ['LabTech', 'ITAdmin'].includes(user.role), [user]);
+  const [order, setOrder] = useState<LabOrderEntry | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [forms, setForms] = useState<ResultForms>({});
+  const [savingItemId, setSavingItemId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!labOrderId) {
+      navigate('/lab-orders');
+      return;
+    }
+  }, [labOrderId, navigate]);
+
+  useEffect(() => {
+    if (!labOrderId) return;
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await getLabOrderDetail(labOrderId);
+        if (!cancelled) {
+          setOrder(data);
+          if (data) {
+            setForms(
+              Object.fromEntries(
+                data.items.map((item) => [
+                  item.labOrderItemId,
+                  {
+                    resultValue: '',
+                    resultValueNum: '',
+                    unit: item.results?.[0]?.unit ?? '',
+                    referenceLow: item.results?.[0]?.referenceLow?.toString() ?? '',
+                    referenceHigh: item.results?.[0]?.referenceHigh?.toString() ?? '',
+                    notes: '',
+                  },
+                ]),
+              ),
+            );
+          }
+        }
+      } catch (err) {
+        console.error(err);
+        if (!cancelled) {
+          setError(t('Unable to load lab order.'));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [labOrderId, t]);
+
+  function updateForm(itemId: string, key: keyof ResultFormState, value: string) {
+    setForms((prev) => ({
+      ...prev,
+      [itemId]: {
+        ...(prev[itemId] ?? {
+          resultValue: '',
+          resultValueNum: '',
+          unit: '',
+          referenceLow: '',
+          referenceHigh: '',
+          notes: '',
+        }),
+        [key]: value,
+      },
+    }));
+  }
+
+  async function handleSubmit(item: LabOrderItemEntry, event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!order || !canEnterResults) return;
+    const state = forms[item.labOrderItemId];
+    if (!state) return;
+
+    const payload: EnterLabResultPayload = {
+      labOrderItemId: item.labOrderItemId,
+      patientId: order.patientId,
+      resultValue: state.resultValue || undefined,
+      resultValueNum: state.resultValueNum ? Number(state.resultValueNum) : undefined,
+      unit: state.unit || undefined,
+      referenceLow: state.referenceLow ? Number(state.referenceLow) : undefined,
+      referenceHigh: state.referenceHigh ? Number(state.referenceHigh) : undefined,
+      notes: state.notes || undefined,
+    };
+
+    setSavingItemId(item.labOrderItemId);
+    setError(null);
+    try {
+      await enterLabResult(payload);
+      const refreshed = await getLabOrderDetail(order.labOrderId);
+      setOrder(refreshed);
+      if (refreshed) {
+        setForms((prev) => ({
+          ...prev,
+          [item.labOrderItemId]: {
+            resultValue: '',
+            resultValueNum: '',
+            unit: state.unit,
+            referenceLow: state.referenceLow,
+            referenceHigh: state.referenceHigh,
+            notes: '',
+          },
+        }));
+      }
+    } catch (err) {
+      console.error(err);
+      setError(t('Unable to save lab result.'));
+    } finally {
+      setSavingItemId(null);
+    }
+  }
+
+  const subtitle = order
+    ? t('Visit {visitId} • Patient {patientId}', {
+        visitId: order.visitId,
+        patientId: order.patientId,
+      })
+    : undefined;
+
+  return (
+    <DashboardLayout title={t('Lab order detail')} subtitle={subtitle} activeItem="patients">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <div className="flex items-center justify-between">
+          <Link
+            to="/lab-orders"
+            className="rounded-full border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-100"
+          >
+            {t('Back to orders')}
+          </Link>
+          {order && (
+            <span className="rounded-full bg-blue-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-blue-700">
+              {order.status.replace('_', ' ')}
+            </span>
+          )}
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        )}
+
+        {loading ? (
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 text-center text-sm text-gray-600">
+            {t('Loading order information...')}
+          </div>
+        ) : order ? (
+          <div className="space-y-6">
+            <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-base font-semibold text-gray-900">{t('Order summary')}</h2>
+              <dl className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                  <dt className="text-xs uppercase text-gray-500">{t('Order ID')}</dt>
+                  <dd className="text-sm text-gray-900">{order.labOrderId}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase text-gray-500">{t('Created')}</dt>
+                  <dd className="text-sm text-gray-900">{new Date(order.createdAt).toLocaleString()}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase text-gray-500">{t('Priority')}</dt>
+                  <dd className="text-sm text-gray-900">{order.priority ?? t('Routine')}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase text-gray-500">{t('Notes')}</dt>
+                  <dd className="text-sm text-gray-900">{order.notes ?? '—'}</dd>
+                </div>
+              </dl>
+            </div>
+
+            <div className="space-y-4">
+              {order.items.map((item) => (
+                <div key={item.labOrderItemId} className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-base font-semibold text-gray-900">{item.testName}</h3>
+                      <p className="text-sm text-gray-500">{item.testCode}</p>
+                    </div>
+                    <span
+                      className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                        item.status === 'RESULTED' ? 'bg-green-100 text-green-700' : 'bg-yellow-100 text-yellow-700'
+                      }`}
+                    >
+                      {t(item.status.replace('_', ' '))}
+                    </span>
+                  </div>
+
+                  <div className="mt-4 space-y-3">
+                    {(item.results ?? []).map((result: LabResultEntry) => (
+                      <div
+                        key={result.labResultId}
+                        className="rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-900"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <div>
+                            <div className="font-semibold">
+                              {result.resultValue ?? result.resultValueNum ?? t('No value provided')}
+                              {result.unit && ` ${result.unit}`}
+                            </div>
+                            <div className="text-xs text-blue-700">
+                              {new Date(result.resultedAt).toLocaleString()}
+                            </div>
+                          </div>
+                          {result.abnormalFlag && (
+                            <span className="rounded-full bg-red-600 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">
+                              {result.abnormalFlag}
+                            </span>
+                          )}
+                        </div>
+                        {(result.referenceLow != null || result.referenceHigh != null) && (
+                          <div className="mt-2 text-xs text-blue-700">
+                            {t('Reference range')}: {result.referenceLow ?? '—'} – {result.referenceHigh ?? '—'}
+                          </div>
+                        )}
+                        {result.notes && <div className="mt-2 text-xs text-blue-800">{result.notes}</div>}
+                      </div>
+                    ))}
+                  </div>
+
+                  {canEnterResults && item.status !== 'RESULTED' && (
+                    <form
+                      onSubmit={(event) => handleSubmit(item, event)}
+                      className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2"
+                    >
+                      <label className="flex flex-col text-sm font-medium text-gray-700">
+                        {t('Result value (text)')}
+                        <input
+                          type="text"
+                          value={forms[item.labOrderItemId]?.resultValue ?? ''}
+                          onChange={(event) => updateForm(item.labOrderItemId, 'resultValue', event.target.value)}
+                          className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                        />
+                      </label>
+                      <label className="flex flex-col text-sm font-medium text-gray-700">
+                        {t('Result value (numeric)')}
+                        <input
+                          type="number"
+                          step="0.001"
+                          value={forms[item.labOrderItemId]?.resultValueNum ?? ''}
+                          onChange={(event) => updateForm(item.labOrderItemId, 'resultValueNum', event.target.value)}
+                          className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                        />
+                      </label>
+                      <label className="flex flex-col text-sm font-medium text-gray-700">
+                        {t('Unit')}
+                        <input
+                          type="text"
+                          value={forms[item.labOrderItemId]?.unit ?? ''}
+                          onChange={(event) => updateForm(item.labOrderItemId, 'unit', event.target.value)}
+                          className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                        />
+                      </label>
+                      <label className="flex flex-col text-sm font-medium text-gray-700">
+                        {t('Reference low')}
+                        <input
+                          type="number"
+                          step="0.001"
+                          value={forms[item.labOrderItemId]?.referenceLow ?? ''}
+                          onChange={(event) => updateForm(item.labOrderItemId, 'referenceLow', event.target.value)}
+                          className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                        />
+                      </label>
+                      <label className="flex flex-col text-sm font-medium text-gray-700">
+                        {t('Reference high')}
+                        <input
+                          type="number"
+                          step="0.001"
+                          value={forms[item.labOrderItemId]?.referenceHigh ?? ''}
+                          onChange={(event) => updateForm(item.labOrderItemId, 'referenceHigh', event.target.value)}
+                          className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                        />
+                      </label>
+                      <label className="flex flex-col text-sm font-medium text-gray-700 sm:col-span-2">
+                        {t('Result notes')}
+                        <textarea
+                          value={forms[item.labOrderItemId]?.notes ?? ''}
+                          onChange={(event) => updateForm(item.labOrderItemId, 'notes', event.target.value)}
+                          className="mt-1 h-20 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                        />
+                      </label>
+                      <div className="sm:col-span-2 flex justify-end">
+                        <button
+                          type="submit"
+                          disabled={savingItemId === item.labOrderItemId}
+                          className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-400"
+                        >
+                          {savingItemId === item.labOrderItemId ? t('Saving...') : t('Submit result')}
+                        </button>
+                      </div>
+                    </form>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 text-center text-sm text-gray-600">
+            {t('Lab order not found.')}
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/src/pages/LabOrders.tsx
+++ b/client/src/pages/LabOrders.tsx
@@ -1,0 +1,360 @@
+import { FormEvent, Fragment, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+import { useAuth } from '../context/AuthProvider';
+import { useTranslation } from '../hooks/useTranslation';
+import {
+  createLabOrder,
+  listLabOrders,
+  type CreateLabOrderPayload,
+  type LabOrderEntry,
+  type LabOrderStatus,
+} from '../api/clinical';
+
+const STATUSES: LabOrderStatus[] = ['ORDERED', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED'];
+
+type LabOrderFormState = {
+  visitId: string;
+  patientId: string;
+  priority: string;
+  notes: string;
+  items: Array<{ testCode: string; testName: string; specimen: string; notes: string }>;
+};
+
+export default function LabOrdersPage() {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const canOrder = useMemo(() => user && ['Doctor', 'ITAdmin'].includes(user.role), [user]);
+  const canView = useMemo(
+    () => user && ['Doctor', 'LabTech', 'ITAdmin'].includes(user.role),
+    [user],
+  );
+  const [orders, setOrders] = useState<LabOrderEntry[]>([]);
+  const [statusFilter, setStatusFilter] = useState<LabOrderStatus>('ORDERED');
+  const [patientFilter, setPatientFilter] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState<LabOrderFormState>({
+    visitId: '',
+    patientId: '',
+    priority: '',
+    notes: '',
+    items: [{ testCode: '', testName: '', specimen: '', notes: '' }],
+  });
+
+  useEffect(() => {
+    if (!canView) return;
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await listLabOrders({
+          status: statusFilter,
+          patientId: patientFilter.trim() || undefined,
+        });
+        if (!cancelled) {
+          setOrders(data);
+        }
+      } catch (err) {
+        console.error(err);
+        if (!cancelled) {
+          setError(t('Unable to fetch lab orders.'));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [canView, patientFilter, statusFilter, t]);
+
+  function updateItem(index: number, key: keyof LabOrderFormState['items'][number], value: string) {
+    setForm((prev) => {
+      const items = prev.items.map((item, idx) => (idx === index ? { ...item, [key]: value } : item));
+      return { ...prev, items };
+    });
+  }
+
+  function addItemRow() {
+    setForm((prev) => ({
+      ...prev,
+      items: [...prev.items, { testCode: '', testName: '', specimen: '', notes: '' }],
+    }));
+  }
+
+  function removeItemRow(index: number) {
+    setForm((prev) => ({
+      ...prev,
+      items: prev.items.filter((_, idx) => idx !== index),
+    }));
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canOrder) return;
+    if (!form.visitId || !form.patientId) {
+      setError(t('Visit ID and patient ID are required.'));
+      return;
+    }
+    const validItems = form.items.filter((item) => item.testCode && item.testName);
+    if (validItems.length === 0) {
+      setError(t('Add at least one lab test.'));
+      return;
+    }
+
+    const payload: CreateLabOrderPayload = {
+      visitId: form.visitId,
+      patientId: form.patientId,
+      priority: form.priority || undefined,
+      notes: form.notes || undefined,
+      items: validItems.map((item) => ({
+        testCode: item.testCode,
+        testName: item.testName,
+        specimen: item.specimen || undefined,
+        notes: item.notes || undefined,
+      })),
+    };
+
+    setSaving(true);
+    setError(null);
+    try {
+      const created = await createLabOrder(payload);
+      setOrders((prev) => (statusFilter === created.status ? [created, ...prev] : prev));
+      setForm({
+        visitId: form.visitId,
+        patientId: form.patientId,
+        priority: '',
+        notes: '',
+        items: [{ testCode: '', testName: '', specimen: '', notes: '' }],
+      });
+    } catch (err) {
+      console.error(err);
+      setError(t('Unable to create lab order.'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const subtitle = patientFilter
+    ? t('Filtering by patient {id}', { id: patientFilter })
+    : t('Manage laboratory workflow');
+
+  return (
+    <DashboardLayout title={t('Laboratory Orders')} subtitle={subtitle} activeItem="patients">
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="space-y-4">
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h2 className="text-base font-semibold text-gray-900">{t('Order entry')}</h2>
+            {!canOrder ? (
+              <p className="mt-2 text-sm text-gray-500">{t('Only doctors or administrators can create lab orders.')}</p>
+            ) : (
+              <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <label className="flex flex-col text-sm font-medium text-gray-700">
+                    {t('Visit ID')}
+                    <input
+                      type="text"
+                      value={form.visitId}
+                      onChange={(event) => setForm((prev) => ({ ...prev, visitId: event.target.value }))}
+                      className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                      required
+                    />
+                  </label>
+                  <label className="flex flex-col text-sm font-medium text-gray-700">
+                    {t('Patient ID')}
+                    <input
+                      type="text"
+                      value={form.patientId}
+                      onChange={(event) => setForm((prev) => ({ ...prev, patientId: event.target.value }))}
+                      className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                      required
+                    />
+                  </label>
+                  <label className="flex flex-col text-sm font-medium text-gray-700">
+                    {t('Priority')}
+                    <input
+                      type="text"
+                      value={form.priority}
+                      onChange={(event) => setForm((prev) => ({ ...prev, priority: event.target.value }))}
+                      className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                      placeholder={t('Routine, Stat, ...')}
+                    />
+                  </label>
+                  <label className="flex flex-col text-sm font-medium text-gray-700 sm:col-span-2">
+                    {t('Clinical notes')}
+                    <textarea
+                      value={form.notes}
+                      onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+                      className="mt-1 h-20 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                    />
+                  </label>
+                </div>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-semibold text-gray-900">{t('Tests')}</h3>
+                    <button
+                      type="button"
+                      onClick={addItemRow}
+                      className="rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-200"
+                    >
+                      {t('Add test')}
+                    </button>
+                  </div>
+                  {form.items.map((item, index) => (
+                    <Fragment key={index}>
+                      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                        <label className="flex flex-col text-sm font-medium text-gray-700">
+                          {t('Test code')}
+                          <input
+                            type="text"
+                            value={item.testCode}
+                            onChange={(event) => updateItem(index, 'testCode', event.target.value)}
+                            className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                            required
+                          />
+                        </label>
+                        <label className="flex flex-col text-sm font-medium text-gray-700">
+                          {t('Test name')}
+                          <input
+                            type="text"
+                            value={item.testName}
+                            onChange={(event) => updateItem(index, 'testName', event.target.value)}
+                            className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                            required
+                          />
+                        </label>
+                        <label className="flex flex-col text-sm font-medium text-gray-700">
+                          {t('Specimen')}
+                          <input
+                            type="text"
+                            value={item.specimen}
+                            onChange={(event) => updateItem(index, 'specimen', event.target.value)}
+                            className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                          />
+                        </label>
+                        <label className="flex flex-col text-sm font-medium text-gray-700">
+                          {t('Notes')}
+                          <input
+                            type="text"
+                            value={item.notes}
+                            onChange={(event) => updateItem(index, 'notes', event.target.value)}
+                            className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                          />
+                        </label>
+                      </div>
+                      {form.items.length > 1 && (
+                        <div className="flex justify-end">
+                          <button
+                            type="button"
+                            onClick={() => removeItemRow(index)}
+                            className="rounded-full bg-red-100 px-3 py-1 text-xs font-semibold text-red-700 hover:bg-red-200"
+                          >
+                            {t('Remove test')}
+                          </button>
+                        </div>
+                      )}
+                    </Fragment>
+                  ))}
+                </div>
+                <div className="flex justify-end">
+                  <button
+                    type="submit"
+                    disabled={saving}
+                    className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-400"
+                  >
+                    {saving ? t('Submitting...') : t('Create lab order')}
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h2 className="text-base font-semibold text-gray-900">{t('Orders')}</h2>
+              <div className="flex items-center gap-2">
+                {STATUSES.map((status) => (
+                  <button
+                    key={status}
+                    type="button"
+                    onClick={() => setStatusFilter(status)}
+                    className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
+                      statusFilter === status
+                        ? 'bg-blue-600 text-white shadow'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    }`}
+                  >
+                    {t(status.replace('_', ' '))}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="mt-4 flex items-center gap-3">
+              <input
+                type="text"
+                value={patientFilter}
+                onChange={(event) => setPatientFilter(event.target.value)}
+                className="w-full rounded-full border border-gray-200 px-4 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                placeholder={t('Filter by patient ID')}
+              />
+            </div>
+            <div className="mt-4 overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+                <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                  <tr>
+                    <th className="px-4 py-3">{t('Order ID')}</th>
+                    <th className="px-4 py-3">{t('Patient')}</th>
+                    <th className="px-4 py-3">{t('Created')}</th>
+                    <th className="px-4 py-3">{t('Priority')}</th>
+                    <th className="px-4 py-3">{t('Tests')}</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {loading ? (
+                    <tr>
+                      <td colSpan={5} className="px-4 py-6 text-center text-sm text-gray-500">
+                        {t('Loading orders...')}
+                      </td>
+                    </tr>
+                  ) : orders.length === 0 ? (
+                    <tr>
+                      <td colSpan={5} className="px-4 py-6 text-center text-sm text-gray-500">
+                        {t('No lab orders in this bucket.')}
+                      </td>
+                    </tr>
+                  ) : (
+                    orders.map((order) => (
+                      <tr
+                        key={order.labOrderId}
+                        className="cursor-pointer transition hover:bg-blue-50"
+                        onClick={() => navigate(`/lab-orders/${order.labOrderId}`)}
+                      >
+                        <td className="px-4 py-3 font-medium text-gray-900">{order.labOrderId}</td>
+                        <td className="px-4 py-3 text-gray-700">{order.patientId}</td>
+                        <td className="px-4 py-3 text-gray-700">{new Date(order.createdAt).toLocaleString()}</td>
+                        <td className="px-4 py-3 text-gray-700">{order.priority ?? '—'}</td>
+                        <td className="px-4 py-3 text-gray-700">{order.items.length}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+            {error && (
+              <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">{error}</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/src/pages/ProblemList.tsx
+++ b/client/src/pages/ProblemList.tsx
@@ -1,0 +1,294 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import DashboardLayout from '../components/DashboardLayout';
+import { useTranslation } from '../hooks/useTranslation';
+import { useAuth } from '../context/AuthProvider';
+import {
+  createProblem,
+  listProblems,
+  updateProblemStatus,
+  type ProblemEntry,
+  type ProblemStatus,
+} from '../api/clinical';
+
+interface Params {
+  patientId: string;
+}
+
+type ProblemFormState = {
+  display: string;
+  codeSystem: string;
+  code: string;
+  onsetDate: string;
+};
+
+export default function ProblemList() {
+  const { t } = useTranslation();
+  const { patientId } = useParams<Params>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const canEdit = useMemo(() => user && ['Doctor', 'ITAdmin'].includes(user.role), [user]);
+  const canResolve = canEdit;
+  const [problems, setProblems] = useState<ProblemEntry[]>([]);
+  const [statusFilter, setStatusFilter] = useState<'ACTIVE' | 'RESOLVED' | 'ALL'>('ACTIVE');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<ProblemFormState>({
+    display: '',
+    codeSystem: '',
+    code: '',
+    onsetDate: '',
+  });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!patientId) {
+      navigate('/patients');
+      return;
+    }
+  }, [patientId, navigate]);
+
+  useEffect(() => {
+    if (!patientId) return;
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await listProblems(patientId, statusFilter === 'ALL' ? undefined : statusFilter);
+        if (!cancelled) {
+          setProblems(data);
+        }
+      } catch (err) {
+        console.error(err);
+        if (!cancelled) {
+          setError(t('Unable to load problem list.'));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [patientId, statusFilter, t]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canEdit || !patientId) return;
+    if (!form.display.trim()) {
+      setError(t('Problem name is required.'));
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const created = await createProblem({
+        patientId,
+        display: form.display.trim(),
+        codeSystem: form.codeSystem ? form.codeSystem.trim() : undefined,
+        code: form.code ? form.code.trim() : undefined,
+        onsetDate: form.onsetDate ? new Date(form.onsetDate).toISOString() : undefined,
+      });
+      setProblems((prev) => [created, ...prev]);
+      setForm({ display: '', codeSystem: '', code: '', onsetDate: '' });
+    } catch (err) {
+      console.error(err);
+      setError(t('Failed to create problem.'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleResolve(problemId: string, status: ProblemStatus) {
+    if (!canResolve) return;
+    try {
+      const resolved = await updateProblemStatus(
+        problemId,
+        status,
+        status === 'RESOLVED' ? new Date().toISOString() : undefined,
+      );
+      setProblems((prev) => prev.map((p) => (p.problemId === problemId ? resolved : p)));
+    } catch (err) {
+      console.error(err);
+      setError(t('Unable to update problem status.'));
+    }
+  }
+
+  const subtitle = patientId ? t('Problems for patient {id}', { id: patientId }) : t('Select a patient');
+
+  return (
+    <DashboardLayout title={t('Problem List')} subtitle={subtitle} activeItem="patients">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <div className="flex items-center justify-between">
+          <Link
+            to={patientId ? `/patients/${patientId}` : '/patients'}
+            className="rounded-full border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-100"
+          >
+            {t('Back to patient')}
+          </Link>
+          <div className="flex items-center gap-2">
+            {['ACTIVE', 'RESOLVED', 'ALL'].map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setStatusFilter(value as typeof statusFilter)}
+                className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                  statusFilter === value
+                    ? 'bg-blue-600 text-white shadow'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                {t(value === 'ALL' ? 'All' : value === 'ACTIVE' ? 'Active' : 'Resolved')}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        )}
+
+        {canEdit && (
+          <form onSubmit={handleSubmit} className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h2 className="text-base font-semibold text-gray-900">{t('Add problem')}</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col text-sm font-medium text-gray-700 sm:col-span-2">
+                {t('Problem name')}
+                <input
+                  type="text"
+                  value={form.display}
+                  onChange={(event) => setForm((prev) => ({ ...prev, display: event.target.value }))}
+                  className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                  required
+                />
+              </label>
+              <label className="flex flex-col text-sm font-medium text-gray-700">
+                {t('Code system')}
+                <input
+                  type="text"
+                  value={form.codeSystem}
+                  onChange={(event) => setForm((prev) => ({ ...prev, codeSystem: event.target.value }))}
+                  className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                  placeholder={t('ICD-10, SNOMED...')}
+                />
+              </label>
+              <label className="flex flex-col text-sm font-medium text-gray-700">
+                {t('Code')}
+                <input
+                  type="text"
+                  value={form.code}
+                  onChange={(event) => setForm((prev) => ({ ...prev, code: event.target.value }))}
+                  className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                />
+              </label>
+              <label className="flex flex-col text-sm font-medium text-gray-700">
+                {t('Onset date')}
+                <input
+                  type="date"
+                  value={form.onsetDate}
+                  onChange={(event) => setForm((prev) => ({ ...prev, onsetDate: event.target.value }))}
+                  className="mt-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+                />
+              </label>
+            </div>
+            <div className="mt-4 flex justify-end">
+              <button
+                type="submit"
+                disabled={saving}
+                className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-400"
+              >
+                {saving ? t('Saving...') : t('Add problem')}
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="rounded-2xl border border-gray-200 bg-white shadow-sm">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+              <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th className="px-4 py-3">{t('Problem')}</th>
+                  <th className="px-4 py-3">{t('Code')}</th>
+                  <th className="px-4 py-3">{t('Onset')}</th>
+                  <th className="px-4 py-3">{t('Status')}</th>
+                  <th className="px-4 py-3">{t('Updated')}</th>
+                  {canResolve && <th className="px-4 py-3 text-right">{t('Actions')}</th>}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {loading ? (
+                  <tr>
+                    <td colSpan={canResolve ? 6 : 5} className="px-4 py-6 text-center text-sm text-gray-500">
+                      {t('Loading problem list...')}
+                    </td>
+                  </tr>
+                ) : problems.length === 0 ? (
+                  <tr>
+                    <td colSpan={canResolve ? 6 : 5} className="px-4 py-6 text-center text-sm text-gray-500">
+                      {t('No problems recorded for this patient.')}
+                    </td>
+                  </tr>
+                ) : (
+                  problems.map((problem) => (
+                    <tr key={problem.problemId}>
+                      <td className="px-4 py-3 text-gray-900">
+                        <div className="font-medium">{problem.display}</div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">
+                        {problem.code ? `${problem.codeSystem ?? ''} ${problem.code}`.trim() : '—'}
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">
+                        {problem.onsetDate ? new Date(problem.onsetDate).toLocaleDateString() : '—'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${
+                            problem.status === 'ACTIVE'
+                              ? 'bg-red-50 text-red-700'
+                              : 'bg-green-50 text-green-700'
+                          }`}
+                        >
+                          {t(problem.status === 'ACTIVE' ? 'Active' : 'Resolved')}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">
+                        {new Date(problem.updatedAt).toLocaleDateString()}
+                      </td>
+                      {canResolve && (
+                        <td className="px-4 py-3 text-right">
+                          {problem.status === 'ACTIVE' ? (
+                            <button
+                              type="button"
+                              className="rounded-full bg-green-600 px-4 py-2 text-xs font-semibold text-white shadow hover:bg-green-700"
+                              onClick={() => handleResolve(problem.problemId, 'RESOLVED')}
+                            >
+                              {t('Mark resolved')}
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              className="rounded-full bg-blue-600 px-4 py-2 text-xs font-semibold text-white shadow hover:bg-blue-700"
+                              onClick={() => handleResolve(problem.problemId, 'ACTIVE')}
+                            >
+                              {t('Reopen')}
+                            </button>
+                          )}
+                        </td>
+                      )}
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -29,6 +29,8 @@ const ROLE_LABELS: Record<Role, string> = {
   Pharmacist: 'Pharmacist',
   PharmacyTech: 'Pharmacy Technician',
   InventoryManager: 'Inventory Manager',
+  Nurse: 'Nurse',
+  LabTech: 'Laboratory Technician',
 };
 
 const ROLE_OPTIONS: Array<{ value: Role; label: string }> = [
@@ -39,6 +41,8 @@ const ROLE_OPTIONS: Array<{ value: Role; label: string }> = [
   { value: 'Pharmacist', label: ROLE_LABELS.Pharmacist },
   { value: 'PharmacyTech', label: ROLE_LABELS.PharmacyTech },
   { value: 'InventoryManager', label: ROLE_LABELS.InventoryManager },
+  { value: 'Nurse', label: ROLE_LABELS.Nurse },
+  { value: 'LabTech', label: ROLE_LABELS.LabTech },
 ];
 
 const DAY_OPTIONS = [

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,9 +1,21 @@
 import type { Config } from 'jest';
 
 const config: Config = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
-  testMatch: ['**/tests/**/*.test.ts', '**/tests/**/*.spec.ts']
+  testMatch: ['**/tests/**/*.test.ts', '**/tests/**/*.spec.ts'],
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: {
+        isolatedModules: true,
+      },
+    },
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 };
 
 export default config;

--- a/prisma/migrations/20250320000100_phase1_clinical/migration.sql
+++ b/prisma/migrations/20250320000100_phase1_clinical/migration.sql
@@ -1,0 +1,163 @@
+-- Extend role enum for clinical staff
+ALTER TYPE "Role" ADD VALUE IF NOT EXISTS 'Nurse';
+ALTER TYPE "Role" ADD VALUE IF NOT EXISTS 'LabTech';
+
+-- Rename legacy lab results table
+ALTER TABLE "LabResult" RENAME TO "VisitLabResult";
+ALTER TABLE "VisitLabResult" RENAME CONSTRAINT "LabResult_pkey" TO "VisitLabResult_pkey";
+ALTER TABLE "VisitLabResult" RENAME CONSTRAINT "LabResult_visitId_fkey" TO "VisitLabResult_visitId_fkey";
+
+-- Ensure dependent indexes use new name
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'LabResult_visitId_idx'
+  ) THEN
+    EXECUTE 'ALTER INDEX "LabResult_visitId_idx" RENAME TO "VisitLabResult_visitId_idx"';
+  END IF;
+END $$;
+
+-- New enums for problem list and laboratory workflows
+DO $$ BEGIN
+  CREATE TYPE "ProblemStatus" AS ENUM ('ACTIVE', 'RESOLVED');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "LabOrderStatus" AS ENUM ('ORDERED', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "LabItemStatus" AS ENUM ('ORDERED', 'RESULTED', 'CANCELLED');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Vitals capture table
+CREATE TABLE IF NOT EXISTS "Vitals" (
+  "vitalsId" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "visitId" UUID NOT NULL,
+  "patientId" UUID NOT NULL,
+  "recordedBy" UUID NOT NULL,
+  "recordedAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "systolic" INTEGER,
+  "diastolic" INTEGER,
+  "heartRate" INTEGER,
+  "temperature" NUMERIC(4,1),
+  "spo2" INTEGER,
+  "heightCm" NUMERIC(5,2),
+  "weightKg" NUMERIC(5,2),
+  "bmi" NUMERIC(5,2),
+  "notes" TEXT
+);
+
+CREATE INDEX IF NOT EXISTS "Vitals_visitId_idx" ON "Vitals" ("visitId");
+CREATE INDEX IF NOT EXISTS "Vitals_patientId_recordedAt_idx" ON "Vitals" ("patientId", "recordedAt");
+
+ALTER TABLE "Vitals"
+  ADD CONSTRAINT "Vitals_visitId_fkey" FOREIGN KEY ("visitId") REFERENCES "Visit" ("visitId") ON DELETE CASCADE;
+ALTER TABLE "Vitals"
+  ADD CONSTRAINT "Vitals_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient" ("patientId") ON DELETE CASCADE;
+ALTER TABLE "Vitals"
+  ADD CONSTRAINT "Vitals_recordedBy_fkey" FOREIGN KEY ("recordedBy") REFERENCES "User" ("userId") ON DELETE RESTRICT;
+
+-- Problem list
+CREATE TABLE IF NOT EXISTS "Problem" (
+  "problemId" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "patientId" UUID NOT NULL,
+  "codeSystem" TEXT,
+  "code" TEXT,
+  "display" TEXT NOT NULL,
+  "onsetDate" TIMESTAMPTZ,
+  "status" "ProblemStatus" NOT NULL DEFAULT 'ACTIVE',
+  "resolvedDate" TIMESTAMPTZ,
+  "createdBy" UUID NOT NULL,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "Problem_patientId_status_idx" ON "Problem" ("patientId", "status");
+
+ALTER TABLE "Problem"
+  ADD CONSTRAINT "Problem_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient" ("patientId") ON DELETE CASCADE;
+ALTER TABLE "Problem"
+  ADD CONSTRAINT "Problem_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User" ("userId") ON DELETE RESTRICT;
+
+-- Computerized provider order entry for labs
+CREATE TABLE IF NOT EXISTS "LabOrder" (
+  "labOrderId" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "visitId" UUID NOT NULL,
+  "patientId" UUID NOT NULL,
+  "doctorId" UUID NOT NULL,
+  "status" "LabOrderStatus" NOT NULL DEFAULT 'ORDERED',
+  "priority" TEXT,
+  "notes" TEXT,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "LabOrder_visitId_status_idx" ON "LabOrder" ("visitId", "status");
+CREATE INDEX IF NOT EXISTS "LabOrder_patientId_status_idx" ON "LabOrder" ("patientId", "status");
+
+ALTER TABLE "LabOrder"
+  ADD CONSTRAINT "LabOrder_visitId_fkey" FOREIGN KEY ("visitId") REFERENCES "Visit" ("visitId") ON DELETE CASCADE;
+ALTER TABLE "LabOrder"
+  ADD CONSTRAINT "LabOrder_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient" ("patientId") ON DELETE CASCADE;
+ALTER TABLE "LabOrder"
+  ADD CONSTRAINT "LabOrder_doctorId_fkey" FOREIGN KEY ("doctorId") REFERENCES "Doctor" ("doctorId") ON DELETE RESTRICT;
+
+CREATE TABLE IF NOT EXISTS "LabOrderItem" (
+  "labOrderItemId" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "labOrderId" UUID NOT NULL,
+  "testCode" TEXT NOT NULL,
+  "testName" TEXT NOT NULL,
+  "status" "LabItemStatus" NOT NULL DEFAULT 'ORDERED',
+  "specimen" TEXT,
+  "notes" TEXT
+);
+
+CREATE INDEX IF NOT EXISTS "LabOrderItem_labOrderId_status_idx" ON "LabOrderItem" ("labOrderId", "status");
+
+ALTER TABLE "LabOrderItem"
+  ADD CONSTRAINT "LabOrderItem_labOrderId_fkey" FOREIGN KEY ("labOrderId") REFERENCES "LabOrder" ("labOrderId") ON DELETE CASCADE;
+
+CREATE TABLE IF NOT EXISTS "LabResult" (
+  "labResultId" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "labOrderId" UUID NOT NULL,
+  "labOrderItemId" UUID NOT NULL,
+  "patientId" UUID NOT NULL,
+  "resultValue" TEXT,
+  "resultValueNum" NUMERIC(10,3),
+  "unit" TEXT,
+  "referenceLow" NUMERIC(10,3),
+  "referenceHigh" NUMERIC(10,3),
+  "abnormalFlag" TEXT,
+  "resultedBy" UUID NOT NULL,
+  "resultedAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "notes" TEXT
+);
+
+CREATE INDEX IF NOT EXISTS "LabResult_labOrderId_idx" ON "LabResult" ("labOrderId");
+CREATE INDEX IF NOT EXISTS "LabResult_labOrderItemId_idx" ON "LabResult" ("labOrderItemId");
+CREATE INDEX IF NOT EXISTS "LabResult_patientId_resultedAt_idx" ON "LabResult" ("patientId", "resultedAt");
+
+ALTER TABLE "LabResult"
+  ADD CONSTRAINT "LabResult_labOrderId_fkey" FOREIGN KEY ("labOrderId") REFERENCES "LabOrder" ("labOrderId") ON DELETE CASCADE;
+ALTER TABLE "LabResult"
+  ADD CONSTRAINT "LabResult_labOrderItemId_fkey" FOREIGN KEY ("labOrderItemId") REFERENCES "LabOrderItem" ("labOrderItemId") ON DELETE CASCADE;
+ALTER TABLE "LabResult"
+  ADD CONSTRAINT "LabResult_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "Patient" ("patientId") ON DELETE CASCADE;
+ALTER TABLE "LabResult"
+  ADD CONSTRAINT "LabResult_resultedBy_fkey" FOREIGN KEY ("resultedBy") REFERENCES "User" ("userId") ON DELETE RESTRICT;
+
+CREATE TABLE IF NOT EXISTS "LabCatalog" (
+  "testCode" TEXT PRIMARY KEY,
+  "testName" TEXT NOT NULL,
+  "unit" TEXT,
+  "refLow" NUMERIC(10,3),
+  "refHigh" NUMERIC(10,3),
+  "panel" BOOLEAN NOT NULL DEFAULT false
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,8 @@ enum Role {
   Pharmacist
   PharmacyTech
   InventoryManager
+  Nurse
+  LabTech
 }
 
 enum AppointmentStatus {
@@ -126,7 +128,7 @@ model Visit {
   doctor       Doctor      @relation(fields: [doctorId], references: [doctorId])
   diagnoses    Diagnosis[]
   medications  Medication[]
-  labResults   LabResult[]
+  labResults   VisitLabResult[]
   observations Observation[]
   prescriptions Prescription[]
   invoices     Invoice[]
@@ -155,7 +157,7 @@ model Medication {
   visit Visit @relation(fields: [visitId], references: [visitId])
 }
 
-model LabResult {
+model VisitLabResult {
   labId           String   @id @default(uuid()) @db.Uuid
   visitId         String   @db.Uuid
   testName        String
@@ -474,4 +476,120 @@ enum ItemSourceType {
   SERVICE
   PHARMACY
   LAB
+}
+
+model Vitals {
+  vitalsId   String   @id @default(uuid()) @db.Uuid
+  visitId    String   @db.Uuid
+  patientId  String   @db.Uuid
+  recordedBy String   @db.Uuid
+  recordedAt DateTime @default(now())
+  systolic   Int?
+  diastolic  Int?
+  heartRate  Int?
+  temperature Decimal? @db.Decimal(4, 1)
+  spo2       Int?
+  heightCm   Decimal? @db.Decimal(5, 2)
+  weightKg   Decimal? @db.Decimal(5, 2)
+  bmi        Decimal? @db.Decimal(5, 2)
+  notes      String?
+
+  @@index([visitId])
+  @@index([patientId, recordedAt])
+}
+
+model Problem {
+  problemId    String   @id @default(uuid()) @db.Uuid
+  patientId    String   @db.Uuid
+  codeSystem   String?
+  code         String?
+  display      String
+  onsetDate    DateTime?
+  status       ProblemStatus @default(ACTIVE)
+  resolvedDate DateTime?
+  createdBy    String   @db.Uuid
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
+
+  @@index([patientId, status])
+}
+
+enum ProblemStatus {
+  ACTIVE
+  RESOLVED
+}
+
+model LabOrder {
+  labOrderId String   @id @default(uuid()) @db.Uuid
+  visitId    String   @db.Uuid
+  patientId  String   @db.Uuid
+  doctorId   String   @db.Uuid
+  status     LabOrderStatus @default(ORDERED)
+  priority   String?
+  notes      String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  items      LabOrderItem[]
+  results    LabResult[]
+
+  @@index([visitId, status])
+  @@index([patientId, status])
+}
+
+enum LabOrderStatus {
+  ORDERED
+  IN_PROGRESS
+  COMPLETED
+  CANCELLED
+}
+
+model LabOrderItem {
+  labOrderItemId String   @id @default(uuid()) @db.Uuid
+  labOrderId     String   @db.Uuid
+  testCode       String
+  testName       String
+  status         LabItemStatus @default(ORDERED)
+  specimen       String?
+  notes          String?
+  LabOrder       LabOrder @relation(fields: [labOrderId], references: [labOrderId], onDelete: Cascade)
+  results        LabResult[]
+
+  @@index([labOrderId, status])
+}
+
+enum LabItemStatus {
+  ORDERED
+  RESULTED
+  CANCELLED
+}
+
+model LabResult {
+  labResultId    String   @id @default(uuid()) @db.Uuid
+  labOrderId     String   @db.Uuid
+  labOrderItemId String   @db.Uuid
+  patientId      String   @db.Uuid
+  resultValue    String?
+  resultValueNum Decimal? @db.Decimal(10, 3)
+  unit           String?
+  referenceLow   Decimal? @db.Decimal(10, 3)
+  referenceHigh  Decimal? @db.Decimal(10, 3)
+  abnormalFlag   String?
+  resultedBy     String
+  resultedAt     DateTime @default(now())
+  notes          String?
+  LabOrder       LabOrder @relation(fields: [labOrderId], references: [labOrderId], onDelete: Cascade)
+  LabOrderItem   LabOrderItem @relation(fields: [labOrderItemId], references: [labOrderItemId], onDelete: Cascade)
+
+  @@index([labOrderId])
+  @@index([labOrderItemId])
+  @@index([patientId, resultedAt])
+}
+
+model LabCatalog {
+  testCode String @id
+  testName String
+  unit     String?
+  refLow   Decimal? @db.Decimal(10, 3)
+  refHigh  Decimal? @db.Decimal(10, 3)
+  panel    Boolean  @default(false)
 }

--- a/prisma/seed.mts
+++ b/prisma/seed.mts
@@ -58,6 +58,89 @@ async function seedPharmacyReference() {
   console.log('✅ Seeded drugs + stock');
 }
 
+async function seedLabCatalog() {
+  const entries: Array<Prisma.LabCatalogUpsertArgs> = [
+    {
+      where: { testCode: 'CBC' },
+      update: {},
+      create: {
+        testCode: 'CBC',
+        testName: 'Complete Blood Count',
+        unit: null,
+        refLow: null,
+        refHigh: null,
+        panel: true,
+      },
+    },
+    {
+      where: { testCode: 'HGB' },
+      update: {},
+      create: {
+        testCode: 'HGB',
+        testName: 'Hemoglobin',
+        unit: 'g/dL',
+        refLow: new Prisma.Decimal(12),
+        refHigh: new Prisma.Decimal(17.5),
+        panel: false,
+      },
+    },
+    {
+      where: { testCode: 'WBC' },
+      update: {},
+      create: {
+        testCode: 'WBC',
+        testName: 'White Blood Cell Count',
+        unit: 'x10^9/L',
+        refLow: new Prisma.Decimal(4),
+        refHigh: new Prisma.Decimal(11),
+        panel: false,
+      },
+    },
+    {
+      where: { testCode: 'PLT' },
+      update: {},
+      create: {
+        testCode: 'PLT',
+        testName: 'Platelet Count',
+        unit: 'x10^9/L',
+        refLow: new Prisma.Decimal(150),
+        refHigh: new Prisma.Decimal(450),
+        panel: false,
+      },
+    },
+    {
+      where: { testCode: 'LFT_ALT' },
+      update: {},
+      create: {
+        testCode: 'LFT_ALT',
+        testName: 'Alanine Aminotransferase (ALT)',
+        unit: 'U/L',
+        refLow: new Prisma.Decimal(7),
+        refHigh: new Prisma.Decimal(56),
+        panel: false,
+      },
+    },
+    {
+      where: { testCode: 'FBS' },
+      update: {},
+      create: {
+        testCode: 'FBS',
+        testName: 'Fasting Blood Sugar',
+        unit: 'mmol/L',
+        refLow: new Prisma.Decimal(3.9),
+        refHigh: new Prisma.Decimal(5.5),
+        panel: false,
+      },
+    },
+  ];
+
+  for (const entry of entries) {
+    await prisma.labCatalog.upsert(entry);
+  }
+
+  console.log('✅ Seeded lab catalog');
+}
+
 async function main() {
   // Run legacy seed first to ensure baseline data remains available.
   await import('./seed.mjs');
@@ -89,6 +172,7 @@ async function main() {
     },
   });
   await seedPharmacyReference();
+  await seedLabCatalog();
 }
 
 main()

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -11,7 +11,9 @@ type RoleName =
   | 'ITAdmin'
   | 'Pharmacist'
   | 'PharmacyTech'
-  | 'InventoryManager';
+  | 'InventoryManager'
+  | 'Nurse'
+  | 'LabTech';
 
 export interface AuthUser {
   userId: string;

--- a/src/modules/insights/index.ts
+++ b/src/modules/insights/index.ts
@@ -126,9 +126,9 @@ router.get('/cohort', requireAuth, async (req: Request, res: Response) => {
   const from = new Date();
   from.setMonth(from.getMonth() - months);
   const results = await prisma.$queryRaw<Array<{ patientId: string; name: string; value: number; date: Date; visitId: string }>>(
-    Prisma.sql`SELECT DISTINCT ON (p."patientId")
+      Prisma.sql`SELECT DISTINCT ON (p."patientId")
         p."patientId", p.name, l."resultValue" AS value, l."testDate" AS date, l."visitId"
-      FROM "LabResult" l
+      FROM "VisitLabResult" l
       JOIN "Visit" v ON l."visitId" = v."visitId"
       JOIN "Patient" p ON v."patientId" = p."patientId"
       WHERE l."testName" = ${test_name}

--- a/src/modules/labs/index.ts
+++ b/src/modules/labs/index.ts
@@ -26,7 +26,7 @@ router.post('/visits/:id/labs', requireAuth, requireRole('Doctor'), async (req: 
   if (!parsed.success) {
     return res.status(400).json({ error: parsed.error.flatten() });
   }
-  const lab = await prisma.labResult.create({ data: { visitId: id, ...parsed.data } });
+  const lab = await prisma.visitLabResult.create({ data: { visitId: id, ...parsed.data } });
   await logDataChange(req.user!.userId, 'lab', lab.labId, undefined, lab);
   res.status(201).json(lab);
 });
@@ -66,7 +66,7 @@ router.get('/', requireAuth, requireRole('Doctor'), async (req: Request, res: Re
       ...(to && { lte: to }),
     };
   }
-  const labs = await prisma.labResult.findMany({
+  const labs = await prisma.visitLabResult.findMany({
     where,
     orderBy: { testDate: 'desc' },
     take: limit,

--- a/src/modules/reports/index.ts
+++ b/src/modules/reports/index.ts
@@ -74,7 +74,7 @@ router.get('/summary', requireAuth, async (_req: Request, res: Response) => {
       orderBy: { _count: { diagnosis: 'desc' } },
       take: 10,
     }),
-    prisma.labResult.groupBy({
+    prisma.visitLabResult.groupBy({
       by: ['testName'],
       where: { testDate: { not: null } },
       _count: { labId: true },

--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -16,6 +16,8 @@ const roleSchema = z.enum([
   'Pharmacist',
   'PharmacyTech',
   'InventoryManager',
+  'Nurse',
+  'LabTech',
 ]);
 const statusSchema = z.enum(['active', 'inactive']);
 

--- a/src/routes/clinical.ts
+++ b/src/routes/clinical.ts
@@ -1,0 +1,188 @@
+import { Router } from 'express';
+import { requireAuth, requireRole, type AuthRequest } from '../modules/auth/index.js';
+import { validate } from '../middleware/validate.js';
+import {
+  CreateLabOrderSchema,
+  CreateProblemSchema,
+  CreateVitalsSchema,
+  EnterLabResultSchema,
+  UpdateProblemStatusSchema,
+} from '../validation/clinical.js';
+import * as vitals from '../services/vitalsService.js';
+import * as problems from '../services/problemService.js';
+import * as labs from '../services/labService.js';
+
+const router = Router();
+
+// Vitals
+router.post(
+  '/vitals',
+  requireAuth,
+  requireRole('Nurse', 'Doctor', 'ITAdmin'),
+  validate({ body: CreateVitalsSchema }),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const user = req.user!;
+      const data = await vitals.createVitals(user.userId, req.body);
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/patients/:patientId/vitals',
+  requireAuth,
+  requireRole('Nurse', 'Doctor', 'ITAdmin'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const limit = Number.parseInt(String(req.query.limit ?? '50'), 10);
+      const data = await vitals.listVitals(req.params.patientId, {
+        limit: Number.isFinite(limit) ? limit : 50,
+      });
+      res.json({ data });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// Problems
+router.post(
+  '/problems',
+  requireAuth,
+  requireRole('Doctor', 'ITAdmin'),
+  validate({ body: CreateProblemSchema }),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const user = req.user!;
+      const data = await problems.addProblem(user.userId, req.body);
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/patients/:patientId/problems',
+  requireAuth,
+  requireRole('Nurse', 'Doctor', 'ITAdmin'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const statusParam = typeof req.query.status === 'string' ? req.query.status : undefined;
+      const data = await problems.listProblems(req.params.patientId, statusParam);
+      res.json({ data });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.patch(
+  '/problems/:problemId/status',
+  requireAuth,
+  requireRole('Doctor', 'ITAdmin'),
+  validate({ body: UpdateProblemStatusSchema }),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const data = await problems.updateProblemStatus(
+        req.params.problemId,
+        req.body.status,
+        req.body.resolvedDate,
+      );
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// Lab Orders & Results
+router.post(
+  '/lab-orders',
+  requireAuth,
+  requireRole('Doctor', 'ITAdmin'),
+  validate({ body: CreateLabOrderSchema }),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const user = req.user!;
+      const data = await labs.createLabOrder(user.userId, req.body);
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/lab-orders',
+  requireAuth,
+  requireRole('LabTech', 'Doctor', 'ITAdmin'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const filters = {
+        patientId: typeof req.query.patientId === 'string' && req.query.patientId.length > 0
+          ? req.query.patientId
+          : undefined,
+        visitId: typeof req.query.visitId === 'string' && req.query.visitId.length > 0
+          ? req.query.visitId
+          : undefined,
+        status: typeof req.query.status === 'string' && req.query.status.length > 0
+          ? req.query.status
+          : undefined,
+      };
+      const data = await labs.listLabOrders(filters);
+      res.json({ data });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/lab-orders/:labOrderId',
+  requireAuth,
+  requireRole('LabTech', 'Doctor', 'ITAdmin'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const data = await labs.getLabOrderDetail(req.params.labOrderId);
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  '/lab-results',
+  requireAuth,
+  requireRole('LabTech', 'ITAdmin'),
+  validate({ body: EnterLabResultSchema }),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const user = req.user!;
+      const data = await labs.enterLabResult(user.userId, req.body);
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.get(
+  '/lab-orders/:labOrderId/report.pdf',
+  requireAuth,
+  requireRole('Doctor', 'LabTech', 'ITAdmin'),
+  async (req: AuthRequest, res, next) => {
+    try {
+      const pdf = await labs.generateLabReportPdf(req.params.labOrderId);
+      res.json({ ok: true, note: 'PDF generation stub', length: pdf.length });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import usersRouter from './modules/users/index.js';
 import reportsRouter from './modules/reports/index.js';
 import pharmacyRouter from './routes/pharmacy.js';
 import billingRouter from './routes/billing.js';
+import clinicalRouter from './routes/clinical.js';
 
 export const apiRouter = Router();
 
@@ -37,6 +38,7 @@ apiRouter.use('/users', usersRouter);
 apiRouter.use('/reports', reportsRouter);
 apiRouter.use('/pharmacy', pharmacyRouter);
 apiRouter.use(billingRouter);
+apiRouter.use(clinicalRouter);
 apiRouter.use(docsRouter);
 
 export default apiRouter;

--- a/src/services/labService.ts
+++ b/src/services/labService.ts
@@ -1,0 +1,225 @@
+import {
+  LabItemStatus,
+  LabOrderStatus,
+  PrismaClient,
+  type LabOrder,
+  type LabOrderItem,
+  type LabResult,
+} from '@prisma/client';
+import type {
+  CreateLabOrderInput,
+  EnterLabResultInput,
+} from '../validation/clinical.js';
+
+const prisma = new PrismaClient();
+
+type LabOrderWithItems = LabOrder & { items: LabOrderItem[] };
+
+type ListLabOrderFilters = {
+  patientId?: string;
+  visitId?: string;
+  status?: string;
+};
+
+export async function createLabOrder(
+  doctorId: string,
+  payload: CreateLabOrderInput,
+): Promise<LabOrderWithItems> {
+  const order = await prisma.labOrder.create({
+    data: {
+      visitId: payload.visitId,
+      patientId: payload.patientId,
+      doctorId,
+      priority: payload.priority ?? null,
+      notes: payload.notes ?? null,
+      items: {
+        create: payload.items.map((item) => ({
+          testCode: item.testCode,
+          testName: item.testName,
+          specimen: item.specimen ?? null,
+          notes: item.notes ?? null,
+        })),
+      },
+    },
+    include: { items: true },
+  });
+
+  return order;
+}
+
+export async function listLabOrders(filters: ListLabOrderFilters) {
+  const where: Record<string, unknown> = {};
+  if (filters.patientId) {
+    where.patientId = filters.patientId;
+  }
+  if (filters.visitId) {
+    where.visitId = filters.visitId;
+  }
+  if (filters.status) {
+    const normalized = filters.status.trim().toUpperCase();
+    if (normalized && Object.values(LabOrderStatus).includes(normalized as LabOrderStatus)) {
+      where.status = normalized;
+    }
+  }
+
+  return prisma.labOrder.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    include: {
+      items: {
+        include: { results: { orderBy: { resultedAt: 'desc' } } },
+      },
+      results: { orderBy: { resultedAt: 'desc' } },
+    },
+  });
+}
+
+export function computeAbnormal(
+  num?: number | null,
+  low?: number | null,
+  high?: number | null,
+): string | null {
+  if (typeof num !== 'number' || Number.isNaN(num)) {
+    return null;
+  }
+  if (typeof low === 'number' && !Number.isNaN(low) && num < low) {
+    return 'L';
+  }
+  if (typeof high === 'number' && !Number.isNaN(high) && num > high) {
+    return 'H';
+  }
+  return null;
+}
+
+async function resolvePatientId(
+  labOrderItemId: string,
+  fallbackPatientId?: string,
+): Promise<{ labOrderId: string; patientId: string }> {
+  const item = await prisma.labOrderItem.findUnique({
+    where: { labOrderItemId },
+    include: { LabOrder: true },
+  });
+  if (!item || !item.LabOrder) {
+    const error = new Error('Lab order item not found');
+    (error as any).statusCode = 404;
+    throw error;
+  }
+
+  return {
+    labOrderId: item.labOrderId,
+    patientId: fallbackPatientId ?? item.LabOrder.patientId,
+  };
+}
+
+async function resolveReferenceDefaults(testCode: string) {
+  if (!testCode) {
+    return { unit: null, refLow: null, refHigh: null };
+  }
+  const entry = await prisma.labCatalog.findUnique({ where: { testCode } });
+  return {
+    unit: entry?.unit ?? null,
+    refLow: entry?.refLow ?? null,
+    refHigh: entry?.refHigh ?? null,
+  };
+}
+
+export async function enterLabResult(
+  labTechUserId: string,
+  payload: EnterLabResultInput,
+): Promise<LabResult> {
+  const { labOrderId, patientId } = await resolvePatientId(
+    payload.labOrderItemId,
+    payload.patientId,
+  );
+
+  const orderItem = await prisma.labOrderItem.findUnique({
+    where: { labOrderItemId: payload.labOrderItemId },
+  });
+  if (!orderItem) {
+    const error = new Error('Lab order item not found');
+    (error as any).statusCode = 404;
+    throw error;
+  }
+
+  let referenceLow = payload.referenceLow ?? null;
+  let referenceHigh = payload.referenceHigh ?? null;
+  let unit = payload.unit ?? null;
+
+  if (referenceLow == null || referenceHigh == null || unit == null) {
+    const defaults = await resolveReferenceDefaults(orderItem.testCode);
+    referenceLow = referenceLow ?? (defaults.refLow ? Number(defaults.refLow) : null);
+    referenceHigh = referenceHigh ?? (defaults.refHigh ? Number(defaults.refHigh) : null);
+    unit = unit ?? defaults.unit;
+  }
+
+  const abnormalFlag = computeAbnormal(
+    payload.resultValueNum ?? null,
+    referenceLow,
+    referenceHigh,
+  );
+
+  const result = await prisma.$transaction(async (tx) => {
+    const created = await tx.labResult.create({
+      data: {
+        labOrderId,
+        labOrderItemId: payload.labOrderItemId,
+        patientId,
+        resultValue: payload.resultValue ?? null,
+        resultValueNum: payload.resultValueNum ?? null,
+        unit,
+        referenceLow,
+        referenceHigh,
+        abnormalFlag,
+        resultedBy: labTechUserId,
+        notes: payload.notes ?? null,
+      },
+    });
+
+    await tx.labOrderItem.update({
+      where: { labOrderItemId: payload.labOrderItemId },
+      data: { status: LabItemStatus.RESULTED },
+    });
+
+    const siblingItems = await tx.labOrderItem.findMany({
+      where: { labOrderId },
+      select: { labOrderItemId: true, status: true },
+    });
+
+    const allResulted = siblingItems.every((item) => item.status === LabItemStatus.RESULTED);
+
+    const currentOrder = await tx.labOrder.findUnique({
+      where: { labOrderId },
+      select: { status: true },
+    });
+
+    if (currentOrder && currentOrder.status !== LabOrderStatus.CANCELLED) {
+      await tx.labOrder.update({
+        where: { labOrderId },
+        data: {
+          status: allResulted ? LabOrderStatus.COMPLETED : LabOrderStatus.IN_PROGRESS,
+        },
+      });
+    }
+
+    return created;
+  });
+
+  return result;
+}
+
+export async function getLabOrderDetail(labOrderId: string) {
+  return prisma.labOrder.findUnique({
+    where: { labOrderId },
+    include: {
+      items: {
+        include: { results: { orderBy: { resultedAt: 'desc' } } },
+      },
+      results: { orderBy: { resultedAt: 'desc' } },
+    },
+  });
+}
+
+export async function generateLabReportPdf(labOrderId: string) {
+  // Placeholder implementation. A real implementation would build a PDF buffer.
+  return Buffer.from(`PDF report for lab order ${labOrderId}`);
+}

--- a/src/services/problemService.ts
+++ b/src/services/problemService.ts
@@ -1,0 +1,55 @@
+import { PrismaClient, ProblemStatus, type Problem } from '@prisma/client';
+import type {
+  CreateProblemInput,
+  UpdateProblemStatusInput,
+} from '../validation/clinical.js';
+
+const prisma = new PrismaClient();
+
+export async function addProblem(userId: string, payload: CreateProblemInput): Promise<Problem> {
+  return prisma.problem.create({
+    data: {
+      patientId: payload.patientId,
+      codeSystem: payload.codeSystem ?? null,
+      code: payload.code ?? null,
+      display: payload.display,
+      onsetDate: payload.onsetDate ? new Date(payload.onsetDate) : null,
+      status: (payload.status as ProblemStatus) ?? ProblemStatus.ACTIVE,
+      resolvedDate: payload.resolvedDate ? new Date(payload.resolvedDate) : null,
+      createdBy: userId,
+    },
+  });
+}
+
+export async function listProblems(
+  patientId: string,
+  status?: string,
+): Promise<Problem[]> {
+  const normalizedStatus = status ? status.trim() : '';
+  const where: { patientId: string; status?: ProblemStatus } = { patientId };
+  if (normalizedStatus) {
+    const maybeStatus = normalizedStatus.toUpperCase() as ProblemStatus;
+    if (Object.values(ProblemStatus).includes(maybeStatus)) {
+      where.status = maybeStatus;
+    }
+  }
+
+  return prisma.problem.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function updateProblemStatus(
+  problemId: string,
+  status: UpdateProblemStatusInput['status'],
+  resolvedDate?: string,
+): Promise<Problem> {
+  return prisma.problem.update({
+    where: { problemId },
+    data: {
+      status: status as ProblemStatus,
+      resolvedDate: resolvedDate ? new Date(resolvedDate) : null,
+    },
+  });
+}

--- a/src/services/vitalsService.ts
+++ b/src/services/vitalsService.ts
@@ -1,0 +1,53 @@
+import { PrismaClient, type Vitals } from '@prisma/client';
+import type { CreateVitalsInput } from '../validation/clinical.js';
+
+const prisma = new PrismaClient();
+
+function calculateBmi(weightKg?: number | null, heightCm?: number | null): number | null {
+  if (weightKg == null || heightCm == null || heightCm === 0) {
+    return null;
+  }
+  const heightMeters = heightCm / 100;
+  if (!Number.isFinite(heightMeters) || heightMeters <= 0) {
+    return null;
+  }
+  const bmi = weightKg / (heightMeters * heightMeters);
+  if (!Number.isFinite(bmi)) {
+    return null;
+  }
+  return Number(bmi.toFixed(2));
+}
+
+export async function createVitals(userId: string, payload: CreateVitalsInput): Promise<Vitals> {
+  const bmi = calculateBmi(payload.weightKg ?? null, payload.heightCm ?? null);
+
+  return prisma.vitals.create({
+    data: {
+      visitId: payload.visitId,
+      patientId: payload.patientId,
+      recordedBy: userId,
+      systolic: payload.systolic ?? null,
+      diastolic: payload.diastolic ?? null,
+      heartRate: payload.heartRate ?? null,
+      temperature: payload.temperature ?? null,
+      spo2: payload.spo2 ?? null,
+      heightCm: payload.heightCm ?? null,
+      weightKg: payload.weightKg ?? null,
+      bmi: bmi ?? null,
+      notes: payload.notes ?? null,
+    },
+  });
+}
+
+export async function listVitals(
+  patientId: string,
+  opts: { limit?: number } = {},
+): Promise<Vitals[]> {
+  return prisma.vitals.findMany({
+    where: { patientId },
+    orderBy: { recordedAt: 'desc' },
+    take: opts.limit ?? 50,
+  });
+}
+
+export { calculateBmi };

--- a/src/validation/clinical.ts
+++ b/src/validation/clinical.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+export const CreateVitalsSchema = z.object({
+  visitId: z.string().uuid(),
+  patientId: z.string().uuid(),
+  systolic: z.number().int().min(40).max(300).nullable().optional(),
+  diastolic: z.number().int().min(20).max(200).nullable().optional(),
+  heartRate: z.number().int().min(20).max(250).nullable().optional(),
+  temperature: z.number().min(30).max(45).nullable().optional(),
+  spo2: z.number().int().min(50).max(100).nullable().optional(),
+  heightCm: z.number().positive().max(250).nullable().optional(),
+  weightKg: z.number().positive().max(400).nullable().optional(),
+  notes: z.string().max(500).optional(),
+});
+
+export const CreateProblemSchema = z.object({
+  patientId: z.string().uuid(),
+  codeSystem: z.string().max(20).optional(),
+  code: z.string().max(20).optional(),
+  display: z.string().min(2).max(120),
+  onsetDate: z.string().datetime().optional(),
+  status: z.enum(['ACTIVE', 'RESOLVED']).optional(),
+  resolvedDate: z.string().datetime().optional(),
+});
+
+export const UpdateProblemStatusSchema = z.object({
+  status: z.enum(['ACTIVE', 'RESOLVED']),
+  resolvedDate: z.string().datetime().optional(),
+});
+
+export const CreateLabOrderSchema = z.object({
+  visitId: z.string().uuid(),
+  patientId: z.string().uuid(),
+  priority: z.string().optional(),
+  notes: z.string().max(500).optional(),
+  items: z
+    .array(
+      z.object({
+        testCode: z.string().min(1),
+        testName: z.string().min(1),
+        specimen: z.string().optional(),
+        notes: z.string().max(300).optional(),
+      }),
+    )
+    .min(1),
+});
+
+export const EnterLabResultSchema = z.object({
+  labOrderItemId: z.string().uuid(),
+  patientId: z.string().uuid().optional(),
+  resultValue: z.string().optional(),
+  resultValueNum: z.number().optional(),
+  unit: z.string().optional(),
+  referenceLow: z.number().optional(),
+  referenceHigh: z.number().optional(),
+  notes: z.string().max(300).optional(),
+});
+
+export type CreateVitalsInput = z.infer<typeof CreateVitalsSchema>;
+export type CreateProblemInput = z.infer<typeof CreateProblemSchema>;
+export type UpdateProblemStatusInput = z.infer<typeof UpdateProblemStatusSchema>;
+export type CreateLabOrderInput = z.infer<typeof CreateLabOrderSchema>;
+export type EnterLabResultInput = z.infer<typeof EnterLabResultSchema>;

--- a/tests/clinical.test.ts
+++ b/tests/clinical.test.ts
@@ -1,0 +1,177 @@
+import request from 'supertest';
+import { PrismaClient } from '@prisma/client';
+import { app } from '../src/index';
+
+const prisma = new PrismaClient();
+
+function makeAuthHeader(userId: string, role: string, email: string) {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ sub: userId, role, email })).toString('base64url');
+  return `Bearer ${header}.${payload}.`;
+}
+
+let doctorUserId: string;
+let nurseUserId: string;
+let labTechUserId: string;
+let visitId: string;
+let patientId: string;
+let labOrderId: string;
+let labOrderItemIds: string[] = [];
+
+beforeAll(async () => {
+  const doctor = await prisma.doctor.create({ data: { name: 'Dr Clinical', department: 'Internal Medicine' } });
+  const patient = await prisma.patient.create({
+    data: { name: 'Test Patient', dob: new Date('1990-01-01'), gender: 'F' },
+  });
+  patientId = patient.patientId;
+  const visit = await prisma.visit.create({
+    data: {
+      patientId,
+      doctorId: doctor.doctorId,
+      visitDate: new Date('2025-01-01'),
+      department: 'General',
+      reason: 'Routine checkup',
+    },
+  });
+  visitId = visit.visitId;
+
+  const doctorUser = await prisma.user.create({
+    data: {
+      email: 'doctor-clinical@example.com',
+      passwordHash: 'x',
+      role: 'Doctor',
+      doctorId: doctor.doctorId,
+    },
+  });
+  doctorUserId = doctorUser.userId;
+
+  const nurseUser = await prisma.user.create({
+    data: { email: 'nurse@example.com', passwordHash: 'x', role: 'Nurse' },
+  });
+  nurseUserId = nurseUser.userId;
+
+  const labTechUser = await prisma.user.create({
+    data: { email: 'labtech@example.com', passwordHash: 'x', role: 'LabTech' },
+  });
+  labTechUserId = labTechUser.userId;
+});
+
+afterAll(async () => {
+  if (labOrderId) {
+    await prisma.labResult.deleteMany({ where: { labOrderId } });
+    await prisma.labOrderItem.deleteMany({ where: { labOrderId } });
+    await prisma.labOrder.deleteMany({ where: { labOrderId } });
+  }
+  await prisma.problem.deleteMany({ where: { patientId } });
+  await prisma.vitals.deleteMany({ where: { patientId } });
+  await prisma.visit.deleteMany({ where: { visitId } });
+  await prisma.patient.deleteMany({ where: { patientId } });
+  await prisma.user.deleteMany({ where: { userId: { in: [doctorUserId, nurseUserId, labTechUserId] } } });
+  await prisma.doctor.deleteMany({ where: { visits: { some: { visitId } } } });
+  await prisma.$disconnect();
+});
+
+describe('Clinical workflows', () => {
+  it('records vitals, manages problems, and completes lab orders', async () => {
+    const nurseAuth = makeAuthHeader(nurseUserId, 'Nurse', 'nurse@example.com');
+    const doctorAuth = makeAuthHeader(doctorUserId, 'Doctor', 'doctor-clinical@example.com');
+    const labTechAuth = makeAuthHeader(labTechUserId, 'LabTech', 'labtech@example.com');
+
+    const vitalsRes = await request(app)
+      .post('/api/vitals')
+      .set('Authorization', nurseAuth)
+      .send({
+        visitId,
+        patientId,
+        systolic: 120,
+        diastolic: 80,
+        heartRate: 72,
+        temperature: 37.1,
+        spo2: 99,
+        heightCm: 170,
+        weightKg: 65,
+      });
+    expect(vitalsRes.status).toBe(200);
+    expect(vitalsRes.body.bmi).toBeDefined();
+    expect(Number(vitalsRes.body.bmi)).toBeCloseTo(22.49, 2);
+
+    const vitalsListRes = await request(app)
+      .get(`/api/patients/${patientId}/vitals`)
+      .set('Authorization', doctorAuth);
+    expect(vitalsListRes.status).toBe(200);
+    expect(Array.isArray(vitalsListRes.body.data)).toBe(true);
+    expect(vitalsListRes.body.data[0].patientId).toBe(patientId);
+
+    const problemRes = await request(app)
+      .post('/api/problems')
+      .set('Authorization', doctorAuth)
+      .send({
+        patientId,
+        codeSystem: 'ICD-10',
+        code: 'I10',
+        display: 'Hypertension',
+      });
+    expect(problemRes.status).toBe(200);
+    expect(problemRes.body.status).toBe('ACTIVE');
+
+    const resolvedRes = await request(app)
+      .patch(`/api/problems/${problemRes.body.problemId}/status`)
+      .set('Authorization', doctorAuth)
+      .send({ status: 'RESOLVED', resolvedDate: new Date().toISOString() });
+    expect(resolvedRes.status).toBe(200);
+    expect(resolvedRes.body.status).toBe('RESOLVED');
+
+    const labOrderRes = await request(app)
+      .post('/api/lab-orders')
+      .set('Authorization', doctorAuth)
+      .send({
+        visitId,
+        patientId,
+        priority: 'ROUTINE',
+        items: [
+          { testCode: 'FBS', testName: 'Fasting Blood Sugar' },
+          { testCode: 'ALT', testName: 'Alanine Aminotransferase' },
+        ],
+      });
+    expect(labOrderRes.status).toBe(200);
+    labOrderId = labOrderRes.body.labOrderId;
+    labOrderItemIds = labOrderRes.body.items.map((item: { labOrderItemId: string }) => item.labOrderItemId);
+    expect(labOrderItemIds).toHaveLength(2);
+
+    const firstResultRes = await request(app)
+      .post('/api/lab-results')
+      .set('Authorization', labTechAuth)
+      .send({
+        labOrderItemId: labOrderItemIds[0],
+        patientId,
+        resultValueNum: 7.0,
+        unit: 'mmol/L',
+        referenceLow: 3.9,
+        referenceHigh: 5.5,
+      });
+    expect(firstResultRes.status).toBe(200);
+    expect(firstResultRes.body.abnormalFlag).toBe('H');
+
+    const secondResultRes = await request(app)
+      .post('/api/lab-results')
+      .set('Authorization', labTechAuth)
+      .send({
+        labOrderItemId: labOrderItemIds[1],
+        patientId,
+        resultValueNum: 30,
+        unit: 'U/L',
+        referenceLow: 10,
+        referenceHigh: 40,
+      });
+    expect(secondResultRes.status).toBe(200);
+
+    const orderRecord = await prisma.labOrder.findUnique({
+      where: { labOrderId },
+      include: { results: true, items: true },
+    });
+    expect(orderRecord?.status).toBe('COMPLETED');
+    expect(orderRecord?.results.length).toBe(2);
+    const abnormalFlags = orderRecord?.results.map((result) => result.abnormalFlag);
+    expect(abnormalFlags).toContain('H');
+  });
+});


### PR DESCRIPTION
## Summary
- add prisma models, migrations, and seeds for vitals, problem list, and lab orders/results along with new Nurse and LabTech roles
- implement clinical validation schemas, service layer, express routes, and RBAC wiring for vitals capture, problem list management, and lab orders/results
- extend client APIs and UI with vitals card, problem list, lab orders list/detail pages, and supporting navigation and types
- add Jest ESM configuration tweaks and an end-to-end clinical workflow test covering vitals, problems, and lab results completion

## Testing
- `npm test -- clinical.test.ts` *(fails: PrismaClientInitializationError – database server unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d91923f60c832eb7ed1ccb6e1a2d5b