### PR TITLE
Fix TypeScript errors for lab results and clinical routes

### DIFF
--- a/scripts/loadCsv.ts
+++ b/scripts/loadCsv.ts
@@ -153,9 +153,9 @@ async function main() {
     if (!visitId) continue;
     const testName = row.test_name;
     const testDate = row.test_date ? new Date(row.test_date) : null;
-    const existing = await prisma.labResult.findFirst({ where: { visitId, testName, testDate } });
+    const existing = await prisma.visitLabResult.findFirst({ where: { visitId, testName, testDate } });
     if (existing) {
-      await prisma.labResult.update({
+      await prisma.visitLabResult.update({
         where: { labId: existing.labId },
         data: {
           resultValue: row.result_value ? parseFloat(row.result_value) : null,
@@ -166,7 +166,7 @@ async function main() {
       });
       updated.labs += 1;
     } else {
-      await prisma.labResult.create({
+      await prisma.visitLabResult.create({
         data: {
           visitId,
           testName,

--- a/src/routes/clinical.ts
+++ b/src/routes/clinical.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type Response, type NextFunction } from 'express';
 import { requireAuth, requireRole, type AuthRequest } from '../modules/auth/index.js';
 import { validate } from '../middleware/validate.js';
 import {
@@ -20,7 +20,7 @@ router.post(
   requireAuth,
   requireRole('Nurse', 'Doctor', 'ITAdmin'),
   validate({ body: CreateVitalsSchema }),
-  async (req: AuthRequest, res, next) => {
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const user = req.user!;
       const data = await vitals.createVitals(user.userId, req.body);
@@ -35,7 +35,7 @@ router.get(
   '/patients/:patientId/vitals',
   requireAuth,
   requireRole('Nurse', 'Doctor', 'ITAdmin'),
-  async (req: AuthRequest, res, next) => {
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const limit = Number.parseInt(String(req.query.limit ?? '50'), 10);
       const data = await vitals.listVitals(req.params.patientId, {
@@ -54,7 +54,7 @@ router.post(
   requireAuth,
   requireRole('Doctor', 'ITAdmin'),
   validate({ body: CreateProblemSchema }),
-  async (req: AuthRequest, res, next) => {
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const user = req.user!;
       const data = await problems.addProblem(user.userId, req.body);
@@ -69,7 +69,7 @@ router.get(
   '/patients/:patientId/problems',
   requireAuth,
   requireRole('Nurse', 'Doctor', 'ITAdmin'),
-  async (req: AuthRequest, res, next) => {
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const statusParam = typeof req.query.status === 'string' ? req.query.status : undefined;
       const data = await problems.listProblems(req.params.patientId, statusParam);
@@ -85,7 +85,7 @@ router.patch(
   requireAuth,
   requireRole('Doctor', 'ITAdmin'),
   validate({ body: UpdateProblemStatusSchema }),
-  async (req: AuthRequest, res, next) => {
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const data = await problems.updateProblemStatus(
         req.params.problemId,
@@ -105,7 +105,7 @@ router.post(
   requireAuth,
   requireRole('Doctor', 'ITAdmin'),
   validate({ body: CreateLabOrderSchema }),
-  async (req: AuthRequest, res, next) => {
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const user = req.user!;
       const data = await labs.createLabOrder(user.userId, req.body);
@@ -120,7 +120,7 @@ router.get(
   '/lab-orders',
   requireAuth,
   requireRole('LabTech', 'Doctor', 'ITAdmin'),
-  async (req: AuthRequest, res, next) => {
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const filters = {
         patientId: typeof req.query.patientId === 'string' && req.query.patientId.length > 0
@@ -145,7 +145,7 @@ router.get(
   '/lab-orders/:labOrderId',
   requireAuth,
   requireRole('LabTech', 'Doctor', 'ITAdmin'),
-  async (req: AuthRequest, res, next) => {
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const data = await labs.getLabOrderDetail(req.params.labOrderId);
       res.json(data);
@@ -160,7 +160,7 @@ router.post(
   requireAuth,
   requireRole('LabTech', 'ITAdmin'),
   validate({ body: EnterLabResultSchema }),
-  async (req: AuthRequest, res, next) => {
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const user = req.user!;
       const data = await labs.enterLabResult(user.userId, req.body);
@@ -175,7 +175,7 @@ router.get(
   '/lab-orders/:labOrderId/report.pdf',
   requireAuth,
   requireRole('Doctor', 'LabTech', 'ITAdmin'),
-  async (req: AuthRequest, res, next) => {
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const pdf = await labs.generateLabReportPdf(req.params.labOrderId);
       res.json({ ok: true, note: 'PDF generation stub', length: pdf.length });


### PR DESCRIPTION
## Summary
- update the CSV loader to use the correct Prisma visitLabResult delegate when syncing lab results
- type Express response/next parameters in clinical routes to satisfy TypeScript checks
- regenerate the Prisma client so the delegate definitions are up to date

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68d9638e44f0832e8440d00ebd285246