### PR TITLE
Fix PatientDetail summary JSX structure

### DIFF
--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -225,124 +225,127 @@ export default function PatientDetail() {
               </Link>
             )}
           </div>
-        ) : (
-          p.visits.map((visit) => {
-            const diagnoses = visit.diagnoses ?? [];
-            const medications = visit.medications ?? [];
-            const labs = visit.labResults ?? [];
-            const observations = visit.observations ?? [];
+          ) : (
+            <>
+              {p.visits.map((visit) => {
+                const diagnoses = visit.diagnoses ?? [];
+                const medications = visit.medications ?? [];
+                const labs = visit.labResults ?? [];
+                const observations = visit.observations ?? [];
 
-            return (
-              <article key={visit.visitId} className="rounded-2xl border border-gray-200 bg-gray-50 p-6 shadow-sm">
-              <div className="flex flex-wrap justify-between gap-4">
-                <div>
-                  <div className="text-sm font-medium text-blue-600">{formatDateValue(visit.visitDate)}</div>
-                  <h3 className="mt-1 text-lg font-semibold text-gray-900">
-                    {t('Visit with {name}', { name: visit.doctor.name })}
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-500">{visit.doctor.department}</p>
-                </div>
-                <Link
-                  to={`/visits/${visit.visitId}`}
-                  className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
-                >
-                  {t('Open visit')}
-                </Link>
-              </div>
-
-              <div className="mt-5 grid gap-5 lg:grid-cols-2">
-                <div className="space-y-4">
-                  <div>
-                    <div className="text-sm font-semibold text-gray-900">{t('Diagnoses')}</div>
-                    {diagnoses.length > 0 ? (
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        {diagnoses.map((diag) => (
-                          <span
-                            key={diag.diagnosis}
-                            className="inline-flex items-center rounded-full bg-red-50 px-3 py-1 text-xs font-medium text-red-700"
-                          >
-                            {diag.diagnosis}
-                          </span>
-                        ))}
+                return (
+                  <article key={visit.visitId} className="rounded-2xl border border-gray-200 bg-gray-50 p-6 shadow-sm">
+                    <div className="flex flex-wrap justify-between gap-4">
+                      <div>
+                        <div className="text-sm font-medium text-blue-600">{formatDateValue(visit.visitDate)}</div>
+                        <h3 className="mt-1 text-lg font-semibold text-gray-900">
+                          {t('Visit with {name}', { name: visit.doctor.name })}
+                        </h3>
+                        <p className="mt-1 text-sm text-gray-500">{visit.doctor.department}</p>
                       </div>
-                    ) : (
-                      <p className="mt-2 text-sm text-gray-500">{t('No diagnoses recorded.')}</p>
-                    )}
-                  </div>
+                      <Link
+                        to={`/visits/${visit.visitId}`}
+                        className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700"
+                      >
+                        {t('Open visit')}
+                      </Link>
+                    </div>
 
-                  <div>
-                    <div className="text-sm font-semibold text-gray-900">{t('Medications')}</div>
-                    {medications.length > 0 ? (
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        {medications.map((med, index) => {
-                          const display = med.dosage ? `${med.drugName} (${med.dosage})` : med.drugName;
-                          return (
-                            <span
-                              key={`${med.drugName}-${index}`}
-                              className="inline-flex items-center rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700"
-                            >
-                              {display}
-                            </span>
-                          );
-                        })}
-                      </div>
-                    ) : (
-                      <p className="mt-2 text-sm text-gray-500">{t('No medications documented.')}</p>
-                    )}
-                  </div>
-                </div>
-
-                <div className="space-y-4">
-                  <div>
-                    <div className="text-sm font-semibold text-gray-900">{t('Key labs')}</div>
-                    {labs.length > 0 ? (
-                      <div className="mt-2 space-y-3">
-                        {labs.map((lab, index) => {
-                          const value =
-                            lab.resultValue !== null && lab.resultValue !== undefined
-                              ? `${lab.resultValue}${lab.unit ? ` ${lab.unit}` : ''}`
-                              : t('Pending');
-                          return (
-                            <div
-                              key={`${lab.testName}-${lab.testDate ?? index}`}
-                              className="rounded-xl border border-blue-100 bg-blue-50 px-4 py-3"
-                            >
-                              <div className="text-sm font-semibold text-blue-700">{lab.testName}</div>
-                              <div className="mt-1 text-base font-semibold text-blue-900">{value}</div>
-                              {lab.testDate && (
-                                <div className="text-xs text-blue-600">
-                                  {t('Collected {date}', { date: formatDateValue(lab.testDate) })}
-                                </div>
-                              )}
+                    <div className="mt-5 grid gap-5 lg:grid-cols-2">
+                      <div className="space-y-4">
+                        <div>
+                          <div className="text-sm font-semibold text-gray-900">{t('Diagnoses')}</div>
+                          {diagnoses.length > 0 ? (
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              {diagnoses.map((diag) => (
+                                <span
+                                  key={diag.diagnosis}
+                                  className="inline-flex items-center rounded-full bg-red-50 px-3 py-1 text-xs font-medium text-red-700"
+                                >
+                                  {diag.diagnosis}
+                                </span>
+                              ))}
                             </div>
-                          );
-                        })}
-                      </div>
-                    ) : (
-                      <p className="mt-2 text-sm text-gray-500">{t('No lab highlights for this visit.')}</p>
-                    )}
-                  </div>
+                          ) : (
+                            <p className="mt-2 text-sm text-gray-500">{t('No diagnoses recorded.')}</p>
+                          )}
+                        </div>
 
-                  <div>
-                    <div className="text-sm font-semibold text-gray-900">{t('Observations')}</div>
-                    {observations.length > 0 ? (
-                      <ul className="mt-2 space-y-2 text-sm text-gray-700">
-                        {observations.map((obs) => (
-                          <li key={obs.obsId} className="rounded-lg border border-gray-200 bg-gray-100 px-4 py-3">
-                            <div>{obs.noteText}</div>
-                            <div className="mt-1 text-xs text-gray-500">{formatDateTimeValue(obs.createdAt)}</div>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="mt-2 text-sm text-gray-500">{t('No recent clinician notes.')}</p>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </article>
-          );
-        })}
+                        <div>
+                          <div className="text-sm font-semibold text-gray-900">{t('Medications')}</div>
+                          {medications.length > 0 ? (
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              {medications.map((med, index) => {
+                                const display = med.dosage ? `${med.drugName} (${med.dosage})` : med.drugName;
+                                return (
+                                  <span
+                                    key={`${med.drugName}-${index}`}
+                                    className="inline-flex items-center rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700"
+                                  >
+                                    {display}
+                                  </span>
+                                );
+                              })}
+                            </div>
+                          ) : (
+                            <p className="mt-2 text-sm text-gray-500">{t('No medications documented.')}</p>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="space-y-4">
+                        <div>
+                          <div className="text-sm font-semibold text-gray-900">{t('Key labs')}</div>
+                          {labs.length > 0 ? (
+                            <div className="mt-2 space-y-3">
+                              {labs.map((lab, index) => {
+                                const value =
+                                  lab.resultValue !== null && lab.resultValue !== undefined
+                                    ? `${lab.resultValue}${lab.unit ? ` ${lab.unit}` : ''}`
+                                    : t('Pending');
+                                return (
+                                  <div
+                                    key={`${lab.testName}-${lab.testDate ?? index}`}
+                                    className="rounded-xl border border-blue-100 bg-blue-50 px-4 py-3"
+                                  >
+                                    <div className="text-sm font-semibold text-blue-700">{lab.testName}</div>
+                                    <div className="mt-1 text-base font-semibold text-blue-900">{value}</div>
+                                    {lab.testDate && (
+                                      <div className="text-xs text-blue-600">
+                                        {t('Collected {date}', { date: formatDateValue(lab.testDate) })}
+                                      </div>
+                                    )}
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          ) : (
+                            <p className="mt-2 text-sm text-gray-500">{t('No lab highlights for this visit.')}</p>
+                          )}
+                        </div>
+
+                        <div>
+                          <div className="text-sm font-semibold text-gray-900">{t('Observations')}</div>
+                          {observations.length > 0 ? (
+                            <ul className="mt-2 space-y-2 text-sm text-gray-700">
+                              {observations.map((obs) => (
+                                <li key={obs.obsId} className="rounded-lg border border-gray-200 bg-gray-100 px-4 py-3">
+                                  <div>{obs.noteText}</div>
+                                  <div className="mt-1 text-xs text-gray-500">{formatDateTimeValue(obs.createdAt)}</div>
+                                </li>
+                              ))}
+                            </ul>
+                          ) : (
+                            <p className="mt-2 text-sm text-gray-500">{t('No recent clinician notes.')}</p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </>
+          )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- wrap the PatientDetail visit summary map in a fragment so the JSX expression closes correctly and resolves the TypeScript parse error

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68d96dabe780832e92464759e2ea930f