### PR TITLE
Fix route param typing on lab order and problem pages

### DIFF
--- a/client/src/pages/LabOrderDetail.tsx
+++ b/client/src/pages/LabOrderDetail.tsx
@@ -12,10 +12,6 @@ import {
   type LabResultEntry,
 } from '../api/clinical';
 
-interface Params {
-  labOrderId: string;
-}
-
 type ResultFormState = {
   resultValue: string;
   resultValueNum: string;
@@ -29,7 +25,7 @@ type ResultForms = Record<string, ResultFormState>;
 
 export default function LabOrderDetailPage() {
   const { t } = useTranslation();
-  const { labOrderId } = useParams<Params>();
+  const { labOrderId } = useParams<'labOrderId'>();
   const navigate = useNavigate();
   const { user } = useAuth();
   const canEnterResults = useMemo(() => user && ['LabTech', 'ITAdmin'].includes(user.role), [user]);
@@ -49,11 +45,11 @@ export default function LabOrderDetailPage() {
   useEffect(() => {
     if (!labOrderId) return;
     let cancelled = false;
-    async function load() {
+    async function load(id: string) {
       setLoading(true);
       setError(null);
       try {
-        const data = await getLabOrderDetail(labOrderId);
+        const data = await getLabOrderDetail(id);
         if (!cancelled) {
           setOrder(data);
           if (data) {
@@ -85,7 +81,7 @@ export default function LabOrderDetailPage() {
         }
       }
     }
-    load();
+    load(labOrderId);
     return () => {
       cancelled = true;
     };

--- a/client/src/pages/ProblemList.tsx
+++ b/client/src/pages/ProblemList.tsx
@@ -11,10 +11,6 @@ import {
   type ProblemStatus,
 } from '../api/clinical';
 
-interface Params {
-  patientId: string;
-}
-
 type ProblemFormState = {
   display: string;
   codeSystem: string;
@@ -24,7 +20,7 @@ type ProblemFormState = {
 
 export default function ProblemList() {
   const { t } = useTranslation();
-  const { patientId } = useParams<Params>();
+  const { patientId } = useParams<'patientId'>();
   const navigate = useNavigate();
   const { user } = useAuth();
   const canEdit = useMemo(() => user && ['Doctor', 'ITAdmin'].includes(user.role), [user]);
@@ -51,11 +47,11 @@ export default function ProblemList() {
   useEffect(() => {
     if (!patientId) return;
     let cancelled = false;
-    async function load() {
+    async function load(id: string) {
       setLoading(true);
       setError(null);
       try {
-        const data = await listProblems(patientId, statusFilter === 'ALL' ? undefined : statusFilter);
+        const data = await listProblems(id, statusFilter === 'ALL' ? undefined : statusFilter);
         if (!cancelled) {
           setProblems(data);
         }
@@ -70,7 +66,7 @@ export default function ProblemList() {
         }
       }
     }
-    load();
+    load(patientId);
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
## Summary
- adjust lab order and problem pages to use key-specific useParams typings
- ensure data loaders receive validated route parameters before fetching data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9e9a7c790832ebd6de52a3d5c6e82