### PR TITLE
Fix unauthorized response when fetching OpenAPI docs

### DIFF
--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -65,7 +65,7 @@ const ListInvoicesQuerySchema = z.object({
     ),
 });
 
-router.use(requireAuth);
+router.use('/billing', requireAuth);
 
 router.post(
   '/billing/invoices',


### PR DESCRIPTION
## Summary
- scope the billing router's auth middleware to only match /billing-prefixed routes
- ensure other API endpoints like /api/docs/openapi.json remain publicly accessible

## Testing
- npx tsx --tsconfig tsconfig.json - <<'TS'
import request from 'supertest';
import { app } from './src/index.ts';
const res = await request(app).get('/api/docs/openapi.json');
console.log(res.status, Object.keys(res.body).slice(0, 5));
TS

------
https://chatgpt.com/codex/tasks/task_e_68ff464ac120832ebfa6ecbaf075eb76